### PR TITLE
Add detailed header comments for ai_gateway_session_handler and ai_gateway_stub_responder files

### DIFF
--- a/server/include/isla/server/ai_gateway_session_handler.hpp
+++ b/server/include/isla/server/ai_gateway_session_handler.hpp
@@ -40,9 +40,11 @@ namespace isla::server::ai_gateway {
 // transcript.seed). Requests exceeding this are rejected with a bad_request
 // error before any application-layer work is done.
 inline constexpr std::size_t kMaxTextInputBytes = 32U * 1024U;
-// Maximum size, in bytes, of a single outbound text.output frame. The
-// application layer is expected to chunk longer responses across multiple
-// EmitTextOutput() calls.
+// Maximum size, in bytes, of a single outbound text.output frame. The FSM
+// currently allows at most one text.output emission per active turn, so the
+// application layer must keep each turn's final reply under this limit
+// rather than splitting it across multiple EmitTextOutput() calls — a second
+// call on the same turn will fail with an invalid-FSM-state error.
 inline constexpr std::size_t kMaxTextOutputBytes = 32U * 1024U;
 
 // Event emitted when a client text.input message has been validated and
@@ -194,8 +196,11 @@ class GatewaySessionHandler {
     // Produces an outgoing `text.output` frame for an active turn and records
     // that text output has been sent for the turn (used by the FSM to decide
     // whether a subsequent `turn.completed` is valid). Rejects empty text,
-    // text exceeding kMaxTextOutputBytes, and writes for turns that are not
-    // currently active.
+    // text exceeding kMaxTextOutputBytes, writes for turns that are not
+    // currently active, and — importantly — a second EmitTextOutput for a
+    // turn that has already emitted text (the FSM currently allows only one
+    // text.output per active turn, so the caller must buffer the full reply
+    // and emit it in a single call rather than streaming chunks).
     [[nodiscard]] absl::StatusOr<EmitResult> EmitTextOutput(std::string_view turn_id,
                                                             std::string_view text);
 

--- a/server/include/isla/server/ai_gateway_session_handler.hpp
+++ b/server/include/isla/server/ai_gateway_session_handler.hpp
@@ -1,5 +1,26 @@
 #pragma once
 
+// ai_gateway_session_handler.hpp
+//
+// Pure protocol-level state machine for a single gateway WebSocket session.
+//
+// GatewaySessionHandler is the translation layer between raw client JSON frames
+// and the structured events consumed by the application layer
+// (GatewayApplicationEventSink / the stub responder). It owns no I/O, no
+// threads, and no transport state — callers feed it one inbound frame at a
+// time, and it returns:
+//   * outgoing JSON frames that must be written back to the client, and
+//   * optional high-level events (session start, transcript seed, turn accept,
+//     turn cancel) that the transport layer routes to the application sink.
+//
+// The class wraps an isla::shared::ai_gateway::SessionState and is responsible
+// for enforcing the protocol FSM (which messages are valid in which state),
+// validating payload shapes and size limits, and producing well-formed
+// response/error frames on behalf of the transport.
+//
+// This header is safe to include from unit tests that want to exercise the
+// protocol logic in isolation without spinning up a real WebSocket server.
+
 #include <cstddef>
 #include <memory>
 #include <optional>
@@ -15,9 +36,21 @@
 
 namespace isla::server::ai_gateway {
 
+// Maximum size, in bytes, of a single inbound text payload (text.input /
+// transcript.seed). Requests exceeding this are rejected with a bad_request
+// error before any application-layer work is done.
 inline constexpr std::size_t kMaxTextInputBytes = 32U * 1024U;
+// Maximum size, in bytes, of a single outbound text.output frame. The
+// application layer is expected to chunk longer responses across multiple
+// EmitTextOutput() calls.
 inline constexpr std::size_t kMaxTextOutputBytes = 32U * 1024U;
 
+// Event emitted when a client text.input message has been validated and
+// accepted by the protocol FSM. The transport layer hands this to the
+// application sink so it can start generating a response. `telemetry_context`
+// is pre-populated with the turn's accept timestamp and is expected to be
+// propagated through every downstream LLM / embedding / memory call for that
+// turn so latency is correctly attributed.
 struct TurnAcceptedEvent {
     std::string session_id;
     std::string turn_id;
@@ -26,23 +59,46 @@ struct TurnAcceptedEvent {
     std::shared_ptr<const TurnTelemetryContext> telemetry_context;
 };
 
-// The same startup payload is used both for pre-start application acceptance and the
-// post-start notification after `session.started` is emitted.
+// Startup payload for a session. The same struct is reused for two distinct
+// events: the pre-start request (where the application sink decides whether
+// to accept the session) and the post-start notification (where the sink is
+// told the `session.started` frame has been emitted and the session is Active).
+// See the SessionStartRequestEvent / SessionStartedEvent aliases below.
 struct SessionStartInfo {
     std::string session_id;
     std::string user_id;
+    // Wall-clock time the client claims the session began. Optional because
+    // older clients may not send it; callers should fall back to server time.
     std::optional<isla::server::memory::Timestamp> session_start_time;
+    // Reference time used for evaluation runs that replay historical sessions —
+    // lets benchmarks pin "now" to a recorded timestamp. Normal production
+    // clients leave this unset.
     std::optional<isla::server::memory::Timestamp> evaluation_reference_time;
 };
 
+// Fires on receipt of a client `session.start` frame, before the application
+// sink has decided whether to accept the session. The application sink's
+// decision is reported back via GatewaySessionHandler::AcceptSessionStart() or
+// RejectSessionStart().
 using SessionStartRequestEvent = SessionStartInfo;
+// Fires after the server has sent `session.started` and the FSM has
+// transitioned to Active. Used by the application sink to finalize any
+// post-accept setup that depends on the session being live.
 using SessionStartedEvent = SessionStartInfo;
 
+// Event emitted when a client `turn.cancel` message has been accepted. The
+// application sink is expected to abort any in-flight work for `turn_id` and
+// emit a `turn.cancelled` frame once cleanup has completed.
 struct TurnCancelRequestedEvent {
     std::string session_id;
     std::string turn_id;
 };
 
+// Event emitted when a client `transcript.seed` message has been accepted.
+// Used to backfill conversation history without invoking the LLM; the
+// application sink persists the message into working memory and then confirms
+// via EmitTranscriptSeeded(). Valid only outside an active turn on an Active
+// session (the FSM enforces this).
 struct TranscriptSeedEvent {
     std::string session_id;
     std::string turn_id;
@@ -51,6 +107,18 @@ struct TranscriptSeedEvent {
     std::optional<isla::server::memory::Timestamp> create_time;
 };
 
+// Outcome of a single HandleIncomingJson() call. Designed so the transport
+// layer can apply it without any further parsing:
+//   1. If `!ok`, the frame was rejected (`error_message` explains why) and
+//      `outgoing_frames` contains a pre-encoded error frame to send back.
+//   2. If `ok`, write any `outgoing_frames` to the client.
+//   3. If any of the optional event fields is populated, dispatch it to the
+//      application sink. At most one of the event fields will be set for a
+//      given inbound frame.
+//   4. If `should_close`, the server should close the connection after the
+//      outgoing frames have flushed (this fires on `session.end`).
+// `error_message` is populated on rejection and is primarily a logging aid —
+// the structured error has already been encoded into `outgoing_frames`.
 struct HandleIncomingResult {
     bool ok = false;
     std::vector<std::string> outgoing_frames;
@@ -62,33 +130,115 @@ struct HandleIncomingResult {
     std::string error_message;
 };
 
+// Outcome of an Emit* call. Each Emit* method produces zero or more fully
+// encoded JSON frames that the transport layer writes back to the client in
+// order. Callers must not reorder frames within a single EmitResult.
 struct EmitResult {
     std::vector<std::string> outgoing_frames;
 };
 
+// Pure protocol-level handler for a single gateway WebSocket session. Owns
+// the session's FSM (wrapping isla::shared::ai_gateway::SessionState) and
+// validates/encodes frames on behalf of the transport layer. One instance per
+// live session; instances are NOT thread-safe — the transport is expected to
+// serialize all calls onto a single session-owned executor (the adapter in
+// ai_gateway_websocket_session.cpp handles this).
+//
+// All methods return either a HandleIncomingResult or an absl::StatusOr<EmitResult>.
+// Returning a non-OK status from an Emit* call means the caller tried to emit
+// from an invalid FSM state (e.g. EmitTextOutput for a turn that isn't
+// active) — these should be treated as server bugs, not client errors, and
+// generally logged loudly.
 class GatewaySessionHandler {
   public:
+    // Constructs a handler for a session with the given id. The telemetry
+    // sink is used to record per-turn phase timings (gateway-accept latency,
+    // turn-accepted events); pass CreateNoOpTelemetrySink() in tests where
+    // telemetry output is not asserted on.
     explicit GatewaySessionHandler(
         std::string session_id,
         std::shared_ptr<const TelemetrySink> telemetry_sink = CreateNoOpTelemetrySink());
 
+    // Parses one inbound JSON frame from the client, validates it against the
+    // current FSM state, and returns a HandleIncomingResult describing what
+    // the transport should do next. This is the single entry point for client
+    // messages — the transport hands every received frame through here.
+    //
+    // On success, exactly one of the result's event fields may be populated
+    // (session_start_requested, transcript_seed, accepted_turn,
+    // cancel_requested); the transport layer forwards that to the application
+    // sink. On failure, `ok` is false, `error_message` explains why, and
+    // `outgoing_frames` already contains a pre-encoded `error` frame to send
+    // back to the client — no additional error emission is required.
+    //
+    // Never throws. Malformed JSON, unknown message types, size-limit
+    // violations, and FSM-order violations (e.g. `text.input` before
+    // `session.start` has completed) are all mapped to rejection results.
     [[nodiscard]] HandleIncomingResult HandleIncomingJson(std::string_view json_text);
+
+    // Transitions the FSM from Starting → Active and produces the outgoing
+    // `session.started` frame. Called by the transport after the application
+    // sink has accepted the SessionStartRequestEvent. Returns a FailedPrecondition
+    // if the FSM is not currently in the Starting state.
     [[nodiscard]] absl::StatusOr<EmitResult> AcceptSessionStart();
+
+    // Transitions the FSM from Starting → Failed and produces an outgoing
+    // `error` frame describing why the session was rejected. Called by the
+    // transport after the application sink has rejected the SessionStartRequestEvent.
+    // Returns a FailedPrecondition if the FSM is not currently in the Starting state.
     [[nodiscard]] absl::StatusOr<EmitResult> RejectSessionStart(std::string_view code,
                                                                 std::string_view message);
+
+    // Produces an outgoing `text.output` frame for an active turn and records
+    // that text output has been sent for the turn (used by the FSM to decide
+    // whether a subsequent `turn.completed` is valid). Rejects empty text,
+    // text exceeding kMaxTextOutputBytes, and writes for turns that are not
+    // currently active.
     [[nodiscard]] absl::StatusOr<EmitResult> EmitTextOutput(std::string_view turn_id,
                                                             std::string_view text);
+
+    // Produces an outgoing `audio.output` frame for an active turn. `audio_base64`
+    // must already be base64-encoded; this method does not re-encode. Rejects
+    // empty mime_type or audio payload and writes for turns that are not
+    // currently active.
     [[nodiscard]] absl::StatusOr<EmitResult> EmitAudioOutput(std::string_view turn_id,
                                                              std::string_view mime_type,
                                                              std::string_view audio_base64);
+
+    // Produces an outgoing `transcript.seeded` confirmation frame for a
+    // transcript-seed request the application sink has just persisted. This
+    // method is `const` because it does not mutate the FSM — it only gates
+    // on the current session being Active. Rejects empty turn_id or role and
+    // emission outside an Active session.
     [[nodiscard]] absl::StatusOr<EmitResult> EmitTranscriptSeeded(std::string_view turn_id,
                                                                   std::string_view role) const;
+
+    // Transitions the active turn to Completed and produces an outgoing
+    // `turn.completed` frame. Called after the application sink has finished
+    // streaming outputs for the turn. Returns a FailedPrecondition if the
+    // turn is not the currently active turn.
     [[nodiscard]] absl::StatusOr<EmitResult> EmitTurnCompleted(std::string_view turn_id);
+
+    // Confirms an in-flight cancellation and produces an outgoing
+    // `turn.cancelled` frame. Called by the transport after the application
+    // sink has finished aborting work in response to a TurnCancelRequestedEvent.
+    // Returns a FailedPrecondition if the turn is not in a cancellable state.
     [[nodiscard]] absl::StatusOr<EmitResult> EmitTurnCancelled(std::string_view turn_id);
+
+    // Produces an out-of-band `error` frame. Used for application-layer
+    // failures that occur outside the normal request/response flow (e.g. LLM
+    // provider outage during a streaming turn). `turn_id` may be null for
+    // session-scoped errors. Does not mutate the FSM, hence `const`.
+    // The outgoing frame's session_id is omitted if the session has not yet
+    // reached Active, so clients cannot correlate pre-start errors with a
+    // session that never existed. Rejects empty code or message.
     [[nodiscard]] absl::StatusOr<EmitResult> EmitError(std::optional<std::string_view> turn_id,
                                                        std::string_view code,
                                                        std::string_view message) const;
 
+    // Read-only view of the underlying session state. Primarily intended for
+    // tests and diagnostic logging; production code should not branch on the
+    // snapshot in place of using the explicit FSM transitions above.
     [[nodiscard]] const isla::shared::ai_gateway::SessionSnapshot& snapshot() const {
         return session_state_.snapshot();
     }

--- a/server/include/isla/server/ai_gateway_session_handler.hpp
+++ b/server/include/isla/server/ai_gateway_session_handler.hpp
@@ -164,10 +164,12 @@ class GatewaySessionHandler {
     // the transport should do next. This is the single entry point for client
     // messages — the transport hands every received frame through here.
     //
-    // On success, exactly one of the result's event fields may be populated
+    // On success, at most one of the result's event fields may be populated
     // (session_start_requested, transcript_seed, accepted_turn,
     // cancel_requested); the transport layer forwards that to the application
-    // sink. On failure, `ok` is false, `error_message` explains why, and
+    // sink. Some frames (e.g. `session.end`) produce outgoing frames but no
+    // event, so callers must tolerate results where every event field is
+    // empty. On failure, `ok` is false, `error_message` explains why, and
     // `outgoing_frames` already contains a pre-encoded `error` frame to send
     // back to the client — no additional error emission is required.
     //

--- a/server/include/isla/server/ai_gateway_stub_responder.hpp
+++ b/server/include/isla/server/ai_gateway_stub_responder.hpp
@@ -240,9 +240,13 @@ struct GatewayAcceptedTurnResult {
 // returning — do not destroy while the owning GatewayServer is still running.
 class GatewayStubResponder final : public GatewayApplicationEventSink {
   public:
-    // Constructs a responder with the given config. All injected clients in
-    // the config are validated lazily on first use (not in the constructor),
-    // so construction is cheap and does not perform network I/O.
+    // Constructs a responder with the given config. The constructor eagerly
+    // initializes mid-term memory components (flush decider, compactor,
+    // sleep-cycle extractor, retrieved-memory reranker) from the injected
+    // clients and warms up the reranker client when present, so any
+    // configuration errors surface immediately via
+    // MidTermMemoryInitializationStatus() rather than on first use. The LLM
+    // and embedding clients themselves are not called during construction.
     explicit GatewayStubResponder(GatewayStubResponderConfig config = {});
     // Stops the worker, joins the thread pool, and tears down all per-session
     // state. Blocks until every in-flight turn either finishes or hits

--- a/server/include/isla/server/ai_gateway_stub_responder.hpp
+++ b/server/include/isla/server/ai_gateway_stub_responder.hpp
@@ -158,8 +158,13 @@ struct GatewayStubResponderConfig {
     // Per-turn LLM runtime parameters (model id, temperature, max tokens, tool
     // catalogue). Shared across all turns produced by this responder.
     GatewayLlmRuntimeConfig llm_runtime_config;
-    // Primary chat LLM client. When null the responder falls back to stubbed
-    // canned replies paced by `response_delay`.
+    // Primary chat LLM client used by the planner/executor path. The
+    // responder always runs turns through the plan executor, so at least
+    // one LLM pathway must be configured: either this `llm_client`, or an
+    // OpenAI Responses client via `openai_client` / enabled `openai_config`.
+    // If no pathway is configured, accepted turns fail with a
+    // FailedPrecondition from the executor rather than falling back to a
+    // canned reply.
     std::shared_ptr<const isla::server::LlmClient> llm_client;
     // Config for an optional OpenAI Responses API client used for the planner/
     // tool-calling execution path. Only consulted when `openai_client` is null
@@ -257,9 +262,15 @@ class GatewayStubResponder final : public GatewayApplicationEventSink {
     // handing it in. The LLM and embedding clients themselves are not
     // invoked during construction.
     explicit GatewayStubResponder(GatewayStubResponderConfig config = {});
-    // Stops the worker, joins the thread pool, and tears down all per-session
-    // state. Blocks until every in-flight turn either finishes or hits
-    // `async_emit_timeout`.
+    // Stops the worker, joins the boost::asio::thread_pool, and tears down
+    // all per-session state. Blocks until every task scheduled on the worker
+    // pool has run to completion — including any in-flight LLM calls, tool
+    // invocations, and memory operations. Only the transport-facing emit
+    // steps are bounded by `async_emit_timeout`; other in-flight work has
+    // no destructor-level timeout, so a wedged LLM call without its own
+    // deadline can stall destruction indefinitely. Callers that need a
+    // hard shutdown bound must cancel/timeout those upstream operations
+    // before destroying the responder.
     ~GatewayStubResponder() override;
 
     GatewayStubResponder(const GatewayStubResponder&) = delete;

--- a/server/include/isla/server/ai_gateway_stub_responder.hpp
+++ b/server/include/isla/server/ai_gateway_stub_responder.hpp
@@ -1,5 +1,34 @@
 #pragma once
 
+// ai_gateway_stub_responder.hpp
+//
+// GatewayStubResponder is the concrete GatewayApplicationEventSink that glues
+// the gateway transport layer to the rest of the server: per-session memory
+// orchestrators, the LLM plan executor, retrieval/rerank clients, and the
+// sleep-cycle boundary. Despite the "stub" name it is the production responder
+// today — the name reflects its origin as a minimal-loop test scaffold that
+// has since grown into the real application layer.
+//
+// Responsibilities:
+//   * Owns a worker thread pool and a per-session Asio strand so turns from a
+//     single session serialize deterministically while distinct sessions run
+//     concurrently.
+//   * Maintains a MemoryOrchestrator per live session and funnels user/
+//     assistant messages through it, producing rendered system + working-
+//     memory prompts for each turn.
+//   * Executes accepted turns end-to-end via GatewayPlanExecutor (LLM call,
+//     tool invocations, streaming text output) and reports the terminal state
+//     back to the transport via the GatewayLiveSession async-emit API.
+//   * Exposes synchronous helpers (RenderSessionMemoryPrompt,
+//     SnapshotSessionWorkingMemoryState, AwaitSessionMemorySettled,
+//     RunSessionSleepCycle, RunAcceptedTurnToCompletion, WaitForAcceptedTurns)
+//     that tests and benchmarks use to drive the responder without a real
+//     WebSocket client.
+//
+// All public methods are thread-safe unless noted otherwise; the transport
+// layer invokes the GatewayApplicationEventSink overrides from the session's
+// I/O strand, and test helpers are typically called from the main thread.
+
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
@@ -31,9 +60,17 @@
 
 namespace isla::server::ai_gateway {
 
+// Default LLM model used by the mid-term flush decider when the caller does
+// not override it via GatewayLlmRuntimeConfig.
 inline constexpr std::string_view kDefaultMidTermMemoryModel = kDefaultMidTermFlushDeciderModel;
+// Default hard cap on the rendered system-prompt section of a turn's prompt.
+// Exceeding this truncates with a warning; the cap exists so a pathological
+// working-memory snapshot cannot blow up the prompt budget.
 inline constexpr std::size_t kDefaultMaxRenderedSystemPromptBytes =
     static_cast<std::size_t>(64U * 1024U);
+// Default hard cap on the rendered working-memory context section of a turn's
+// prompt. Independent from the system-prompt cap so retrieval results can be
+// sized separately from static instructions.
 inline constexpr std::size_t kDefaultMaxRenderedWorkingMemoryContextBytes =
     static_cast<std::size_t>(64U * 1024U);
 
@@ -46,12 +83,20 @@ class GatewaySessionClock {
   public:
     virtual ~GatewaySessionClock() = default;
 
+    // Returns the wall-clock timestamp at which `session_id` should be
+    // considered to have started. Production clocks return nullopt so the
+    // responder falls back to the current wall-clock time; eval replay clocks
+    // return the recorded session start so downstream memory writes line up
+    // with the replay transcript.
     [[nodiscard]] virtual std::optional<isla::server::memory::Timestamp>
     ResolveSessionStartTime(std::string_view session_id) const {
         static_cast<void>(session_id);
         return std::nullopt;
     }
 
+    // Returns the wall-clock timestamp for a specific user or assistant
+    // message within a turn. Same production-vs-replay contract as
+    // ResolveSessionStartTime: nullopt means "use wall-clock now".
     [[nodiscard]] virtual std::optional<isla::server::memory::Timestamp>
     ResolveConversationMessageTime(std::string_view session_id, std::string_view turn_id,
                                    isla::server::memory::MessageRole role) const {
@@ -61,6 +106,10 @@ class GatewaySessionClock {
         return std::nullopt;
     }
 
+    // Returns the "reference now" used by memory decay and activeness
+    // computations. Production returns nullopt (falls back to wall-clock now);
+    // eval replay pins this to the recorded transcript time so decay curves
+    // are deterministic across replay runs.
     [[nodiscard]] virtual std::optional<isla::server::memory::Timestamp>
     ResolveEvaluationReferenceTime(std::string_view session_id) const {
         static_cast<void>(session_id);
@@ -68,8 +117,20 @@ class GatewaySessionClock {
     }
 };
 
+// Tunables and injected dependencies for GatewayStubResponder. Default-
+// constructed configs yield a minimal in-memory responder with no persistence,
+// no LLM, and stub timing — suitable for unit tests. Production callers
+// populate the memory_store / llm_client / openai_client / embedding_client /
+// reranker_client fields to wire in real backends.
 struct GatewayStubResponderConfig {
+    // Baseline artificial delay inserted before emitting a stubbed reply when
+    // no real LLM client is configured. Exists purely so tests can exercise
+    // timing-sensitive paths (cancellation, overlap) without a real provider.
     std::chrono::milliseconds response_delay{ 50 };
+    // Upper bound on any single async emit back to the transport layer. If a
+    // GatewayLiveSession async-emit callback does not fire within this window
+    // the responder logs and treats the emit as failed so it cannot block the
+    // worker thread indefinitely on a wedged transport.
     std::chrono::milliseconds async_emit_timeout{ std::chrono::seconds(2) };
     // Number of shared worker threads used for session startup and accepted-turn execution.
     // A value of 0 uses an implementation-defined default.
@@ -77,77 +138,185 @@ struct GatewayStubResponderConfig {
     // Total number of attempts to persist a session on startup. A value of 0 is
     // treated as 1. At least one attempt is always made if a memory store is configured.
     std::size_t session_start_persistence_max_attempts = 3;
+    // Fixed delay between session-start persistence retries. No exponential
+    // backoff — session start is on the hot path for a connecting client and
+    // the retry budget is small by design.
     std::chrono::milliseconds session_start_persistence_retry_delay{ 100 };
     // The flush decider runs after an assistant reply only when at least this many new user turns
     // have accumulated since the last decider run.
     std::size_t mid_term_flush_decider_interval_user_turns =
         isla::server::memory::kDefaultMidTermFlushDeciderIntervalUserTurns;
+    // Persistent memory backend. When null, the responder runs in fully
+    // in-memory mode: sessions are created without durable state, sleep
+    // cycles become no-ops, and all memory reads/writes stay process-local.
     isla::server::memory::MemoryStorePtr memory_store;
+    // Per-turn LLM runtime parameters (model id, temperature, max tokens, tool
+    // catalogue). Shared across all turns produced by this responder.
     GatewayLlmRuntimeConfig llm_runtime_config;
+    // Primary chat LLM client. When null the responder falls back to stubbed
+    // canned replies paced by `response_delay`.
     std::shared_ptr<const isla::server::LlmClient> llm_client;
+    // Config for an optional OpenAI Responses API client used for the planner/
+    // tool-calling execution path. Only consulted when `openai_client` is null
+    // and the responder needs to construct one internally.
     OpenAiResponsesClientConfig openai_config;
+    // Pre-constructed OpenAI Responses client. When provided, takes precedence
+    // over `openai_config` and is shared directly with the plan executor.
     std::shared_ptr<const OpenAiResponsesClient> openai_client;
+    // Config for an optional Gemini embedding client used by the retrieval
+    // path and sleep-cycle edge embedding. Only consulted when
+    // `embedding_client` is null.
     GeminiApiEmbeddingClientConfig gemini_api_embedding_config;
+    // Pre-constructed embedding client. Shared between read-path similarity
+    // search and write-path relationship-edge embedding; see
+    // embedding_client.hpp for the error-handling contract.
     std::shared_ptr<const isla::server::EmbeddingClient> embedding_client;
+    // Config for an optional Jina cross-encoder reranker used to rescore the
+    // retrieval candidate set. Only consulted when `reranker_client` is null.
     JinaApiRerankerClientConfig jina_api_reranker_config;
+    // Pre-constructed reranker client. When null, the retrieval pipeline
+    // skips the rerank pass and uses first-pass ordering directly.
     std::shared_ptr<const isla::server::RerankerClient> reranker_client;
+    // Candidates whose reranker score falls below this threshold are dropped
+    // from the retrieval set before prompt rendering.
     double retrieved_memory_reranker_min_score =
         isla::server::memory::kDefaultRetrievedMemoryRerankerMinScore;
+    // Per-turn cap on the rendered system-prompt section (see
+    // kDefaultMaxRenderedSystemPromptBytes).
     std::size_t max_rendered_system_prompt_bytes = kDefaultMaxRenderedSystemPromptBytes;
+    // Per-turn cap on the rendered working-memory context section (see
+    // kDefaultMaxRenderedWorkingMemoryContextBytes).
     std::size_t max_rendered_working_memory_context_bytes =
         kDefaultMaxRenderedWorkingMemoryContextBytes;
-    // Defaults to the sum of the system-prompt and working-memory budgets when unset.
+    // Overall per-turn prompt byte budget. Defaults to the sum of the
+    // system-prompt and working-memory budgets when unset; set explicitly
+    // to impose a tighter combined cap.
     std::optional<std::size_t> max_rendered_prompt_bytes;
+    // Test hook fired whenever the plan executor produces a new ExecutionPlan
+    // for a turn. Production leaves this unset; tests use it to assert on
+    // planner behaviour without reaching into the executor.
     std::function<void(const ExecutionPlan&)> on_execution_plan;
+    // Optional session-scoped clock for deterministic eval replay. When null,
+    // all timestamp resolution falls through to wall-clock time.
     std::shared_ptr<const GatewaySessionClock> session_clock;
+    // Test hook fired as soon as a turn's retrieval result is ready (before
+    // the LLM call). Used by eval harnesses to assert on retrieved memory
+    // content without having to serialize through the reply text.
     std::function<void(std::string_view, const isla::server::memory::UserQueryMemoryResult&)>
         on_user_query_memory_ready;
 };
 
+// Terminal disposition of an accepted turn after RunAcceptedTurnToCompletion
+// (or the async worker loop) has driven it to completion. Mirrors the
+// turn.completed / turn.cancelled / error frames emitted on the wire.
 enum class GatewayAcceptedTurnTerminalState {
     kSucceeded,
     kFailed,
     kCancelled,
 };
 
+// Structured failure payload attached to a turn that terminated in kFailed.
+// `code` matches the wire-level error code emitted to the client; `message`
+// is a human-readable detail suitable for logging.
 struct GatewayAcceptedTurnFailure {
     std::string code;
     std::string message;
 };
 
+// Aggregated result returned by RunAcceptedTurnToCompletion. `reply_text` is
+// populated on kSucceeded (the final assistant text handed back to the
+// client); `failure` is populated on kFailed; both are nullopt on kCancelled.
 struct GatewayAcceptedTurnResult {
     GatewayAcceptedTurnTerminalState state = GatewayAcceptedTurnTerminalState::kFailed;
     std::optional<std::string> reply_text;
     std::optional<GatewayAcceptedTurnFailure> failure;
 };
 
+// Production GatewayApplicationEventSink implementation. See the file-level
+// header for the overall role. The class is thread-safe: event-sink overrides
+// can be called from the gateway I/O thread, test helpers from the main
+// thread, and the internal worker thread handles accepted turns concurrently.
+// Destruction stops the worker pool and drains any in-flight turns before
+// returning — do not destroy while the owning GatewayServer is still running.
 class GatewayStubResponder final : public GatewayApplicationEventSink {
   public:
+    // Constructs a responder with the given config. All injected clients in
+    // the config are validated lazily on first use (not in the constructor),
+    // so construction is cheap and does not perform network I/O.
     explicit GatewayStubResponder(GatewayStubResponderConfig config = {});
+    // Stops the worker, joins the thread pool, and tears down all per-session
+    // state. Blocks until every in-flight turn either finishes or hits
+    // `async_emit_timeout`.
     ~GatewayStubResponder() override;
 
     GatewayStubResponder(const GatewayStubResponder&) = delete;
     GatewayStubResponder& operator=(const GatewayStubResponder&) = delete;
 
+    // Wires the responder to the GatewayServer's session registry so it can
+    // look up live sessions by id for out-of-band emits (error frames, turn
+    // outputs from the worker thread). Must be called before Start() on the
+    // owning server — typically immediately after both have been constructed.
     void AttachSessionRegistry(GatewaySessionRegistry* session_registry);
 
+    // Synchronous session-start handler. Kept for tests and simple callers
+    // that prefer a blocking API; production paths go through
+    // HandleSessionStartAsync so the I/O thread is not held while the memory
+    // store is touched. Returns OK if the session was provisioned (or can be)
+    // and non-OK to reject the session-start frame.
     [[nodiscard]] absl::Status HandleSessionStart(const SessionStartRequestEvent& event) override;
+    // Async session-start handler used by the transport. The responder hops
+    // onto its worker pool, initializes per-session memory (with retry per
+    // `session_start_persistence_max_attempts`), and then invokes
+    // `on_complete` with OK to accept or a non-OK status to reject.
     void HandleSessionStartAsync(const SessionStartRequestEvent& event,
                                  GatewayEmitCallback on_complete) override;
+    // Post-accept hook: called after the transport has emitted
+    // `session.started`. Finalizes any state that had to wait for the session
+    // to be live (e.g. pre-warming retrieval caches).
     void OnSessionStarted(const SessionStartedEvent& event) override;
+    // Transcript seed handler. Persists the seeded message into the session's
+    // working memory without invoking the LLM and returns OK on success. Used
+    // by eval harnesses to backfill conversation history.
     [[nodiscard]] absl::Status HandleTranscriptSeed(const TranscriptSeedEvent& event) override;
+    // Fires for every accepted user turn. The responder snapshots the turn
+    // onto its internal queue and schedules execution on the session's
+    // strand; the actual LLM call and reply emission happen asynchronously.
     void OnTurnAccepted(const TurnAcceptedEvent& event) override;
+    // Fires when a client requests cancellation of an in-flight turn. Marks
+    // the tracked turn as cancelled so the worker thread aborts at the next
+    // safe point and emits a `turn.cancelled` frame.
     void OnTurnCancelRequested(const TurnCancelRequestedEvent& event) override;
+    // Fires when a session closes (client disconnect, error, or orderly
+    // shutdown). Tears down the per-session memory orchestrator and forgets
+    // any tracked turns belonging to the session.
     void OnSessionClosed(const SessionClosedEvent& event) override;
+    // Fires once from GatewayServer::Stop() before sessions are asked to
+    // drain. The responder uses this hook to terminate accepted turns that
+    // are still queued with a server-stopping error so they do not block
+    // shutdown on the per-session grace period.
     void OnServerStopping(GatewaySessionRegistry& session_registry) override;
+    // Appends a user message to the session's working memory out-of-band
+    // (i.e. without going through the gateway turn pipeline). Intended for
+    // test harnesses and eval replay that construct conversation history
+    // directly. Returns NotFound if the session has no memory state.
     [[nodiscard]] absl::Status AppendSessionUserMessage(std::string_view session_id,
                                                         std::string_view turn_id,
                                                         std::string_view text);
+    // Appends an assistant message to the session's working memory
+    // out-of-band. Same semantics as AppendSessionUserMessage; used to seed
+    // prior assistant replies into history for deterministic replay.
     [[nodiscard]] absl::Status AppendSessionAssistantMessage(std::string_view session_id,
                                                              std::string_view turn_id,
                                                              std::string_view text);
+    // Renders the current system-prompt + working-memory context string for
+    // the session, applying the configured byte budgets. Primarily a test
+    // and debugging helper — production turns render implicitly as part of
+    // OnTurnAccepted.
     [[nodiscard]] absl::StatusOr<std::string>
     RenderSessionMemoryPrompt(std::string_view session_id) const;
+    // Returns a deep copy of the session's current working-memory state.
+    // Callers that need a fully-settled snapshot (no pending mid-term
+    // compactions in flight) should call AwaitSessionMemorySettled first.
     [[nodiscard]] absl::StatusOr<isla::server::memory::WorkingMemoryState>
     SnapshotSessionWorkingMemoryState(std::string_view session_id) const;
     // Blocks until all pending mid-term memory work for the session has completed and been applied.
@@ -158,11 +327,30 @@ class GatewayStubResponder final : public GatewayApplicationEventSink {
     // work, clears the transient working set, and persists the reset snapshot.
     [[nodiscard]] absl::StatusOr<isla::server::memory::SleepCycleResult>
     RunSessionSleepCycle(std::string_view session_id, isla::server::memory::Timestamp cycle_time);
+    // Synchronously drives an accepted turn through retrieval, LLM execution,
+    // reply emission, and post-reply memory updates, returning the terminal
+    // result. Used by tests and benchmarks that want to run turns without a
+    // real client; production turns go through OnTurnAccepted + the worker.
     [[nodiscard]] absl::StatusOr<GatewayAcceptedTurnResult>
     RunAcceptedTurnToCompletion(const TurnAcceptedEvent& event);
+    // Blocks until the responder's cumulative accepted-turn count reaches at
+    // least `expected_count`, or until shutdown. Returns true on success,
+    // false if the responder stopped before the count was reached. Used by
+    // tests to synchronize on "all expected turns have been dispatched".
     [[nodiscard]] bool WaitForAcceptedTurns(std::size_t expected_count);
+    // True when the config supplies every dependency needed for mid-term
+    // memory (store, LLM, compactor). Does not verify runtime availability —
+    // use IsMidTermMemoryAvailable for that.
     [[nodiscard]] bool IsMidTermMemoryConfigured() const;
+    // True when mid-term memory is both configured AND its one-time
+    // initialization (decider/compactor/extractor construction) succeeded.
+    // False if configuration is missing or initialization returned a non-OK
+    // status; see MidTermMemoryInitializationStatus for the failure detail.
     [[nodiscard]] bool IsMidTermMemoryAvailable() const;
+    // Terminal status of mid-term memory initialization. OK if available or
+    // not configured; a captured non-OK status explains why initialization
+    // failed (e.g. unreachable store, bad model id). Stable for the lifetime
+    // of the responder — initialization is attempted once at construction.
     [[nodiscard]] const absl::Status& MidTermMemoryInitializationStatus() const;
 
   private:

--- a/server/include/isla/server/ai_gateway_stub_responder.hpp
+++ b/server/include/isla/server/ai_gateway_stub_responder.hpp
@@ -64,13 +64,16 @@ namespace isla::server::ai_gateway {
 // not override it via GatewayLlmRuntimeConfig.
 inline constexpr std::string_view kDefaultMidTermMemoryModel = kDefaultMidTermFlushDeciderModel;
 // Default hard cap on the rendered system-prompt section of a turn's prompt.
-// Exceeding this truncates with a warning; the cap exists so a pathological
-// working-memory snapshot cannot blow up the prompt budget.
+// Exceeding the cap logs an ERROR and fails the turn (the responder rejects
+// the rendered prompt rather than silently truncating) so a pathological
+// working-memory snapshot cannot quietly blow through the provider's token
+// budget.
 inline constexpr std::size_t kDefaultMaxRenderedSystemPromptBytes =
     static_cast<std::size_t>(64U * 1024U);
 // Default hard cap on the rendered working-memory context section of a turn's
 // prompt. Independent from the system-prompt cap so retrieval results can be
-// sized separately from static instructions.
+// sized separately from static instructions. Enforcement is identical: the
+// turn is rejected rather than truncated when the limit is exceeded.
 inline constexpr std::size_t kDefaultMaxRenderedWorkingMemoryContextBytes =
     static_cast<std::size_t>(64U * 1024U);
 
@@ -123,9 +126,11 @@ class GatewaySessionClock {
 // populate the memory_store / llm_client / openai_client / embedding_client /
 // reranker_client fields to wire in real backends.
 struct GatewayStubResponderConfig {
-    // Baseline artificial delay inserted before emitting a stubbed reply when
-    // no real LLM client is configured. Exists purely so tests can exercise
-    // timing-sensitive paths (cancellation, overlap) without a real provider.
+    // Per-turn scheduling delay applied unconditionally in OnTurnAccepted
+    // before the worker picks up the turn — it opens a cancellation window
+    // between accept and execution and gives tests a knob for simulating
+    // provider latency. Applies to every accepted turn regardless of
+    // whether a real LLM client is configured.
     std::chrono::milliseconds response_delay{ 50 };
     // Upper bound on any single async emit back to the transport layer. If a
     // GatewayLiveSession async-emit callback does not fire within this window
@@ -242,11 +247,15 @@ class GatewayStubResponder final : public GatewayApplicationEventSink {
   public:
     // Constructs a responder with the given config. The constructor eagerly
     // initializes mid-term memory components (flush decider, compactor,
-    // sleep-cycle extractor, retrieved-memory reranker) from the injected
-    // clients and warms up the reranker client when present, so any
-    // configuration errors surface immediately via
-    // MidTermMemoryInitializationStatus() rather than on first use. The LLM
-    // and embedding clients themselves are not called during construction.
+    // sleep-cycle extractor) from the injected clients; failures there are
+    // captured and exposed via MidTermMemoryInitializationStatus() so callers
+    // can detect them programmatically. The retrieved-memory reranker is
+    // also constructed and warmed up eagerly, but any reranker creation or
+    // warmup failure is logged only and does NOT flow into
+    // MidTermMemoryInitializationStatus() — callers that need to hard-fail
+    // startup on a bad reranker must validate the client themselves before
+    // handing it in. The LLM and embedding clients themselves are not
+    // invoked during construction.
     explicit GatewayStubResponder(GatewayStubResponderConfig config = {});
     // Stops the worker, joins the thread pool, and tears down all per-session
     // state. Blocks until every in-flight turn either finishes or hits
@@ -342,9 +351,12 @@ class GatewayStubResponder final : public GatewayApplicationEventSink {
     // false if the responder stopped before the count was reached. Used by
     // tests to synchronize on "all expected turns have been dispatched".
     [[nodiscard]] bool WaitForAcceptedTurns(std::size_t expected_count);
-    // True when the config supplies every dependency needed for mid-term
-    // memory (store, LLM, compactor). Does not verify runtime availability —
-    // use IsMidTermMemoryAvailable for that.
+    // True when the config supplies an LLM pathway (either `llm_client` or
+    // `openai_client`) that mid-term memory can drive. This is a necessary
+    // but not sufficient condition: a missing memory store or a failure in
+    // CreateMidTermMemoryComponents will still leave mid-term memory
+    // unavailable at runtime. Use IsMidTermMemoryAvailable() to check
+    // whether mid-term memory is actually usable.
     [[nodiscard]] bool IsMidTermMemoryConfigured() const;
     // True when mid-term memory is both configured AND its one-time
     // initialization (decider/compactor/extractor construction) succeeded.
@@ -352,9 +364,15 @@ class GatewayStubResponder final : public GatewayApplicationEventSink {
     // status; see MidTermMemoryInitializationStatus for the failure detail.
     [[nodiscard]] bool IsMidTermMemoryAvailable() const;
     // Terminal status of mid-term memory initialization. OK if available or
-    // not configured; a captured non-OK status explains why initialization
-    // failed (e.g. unreachable store, bad model id). Stable for the lifetime
-    // of the responder — initialization is attempted once at construction.
+    // not configured; a captured non-OK status explains why
+    // CreateMidTermMemoryComponents() failed — for example an invalid
+    // flush-decider or compactor model id, a missing required LLM pathway,
+    // or an embedding client that failed its readiness check. Note that
+    // MemoryStore reachability is NOT validated here; the store is only
+    // touched at runtime on session start / persistence, so a broken store
+    // will surface as a HandleSessionStart failure rather than through this
+    // status. Stable for the lifetime of the responder — initialization is
+    // attempted once at construction.
     [[nodiscard]] const absl::Status& MidTermMemoryInitializationStatus() const;
 
   private:


### PR DESCRIPTION
Enhance code documentation by adding detailed header comments to the ai_gateway_session_handler and ai_gateway_stub_responder files.