### PR TITLE
Implement retrieval ranking for relationships using cosine similarity

### DIFF
--- a/server/memory/include/isla/server/memory/memory_orchestrator.hpp
+++ b/server/memory/include/isla/server/memory/memory_orchestrator.hpp
@@ -24,6 +24,8 @@ class EmbeddingClient;
 namespace isla::server::memory {
 
 inline constexpr int kDefaultEpisodeSimilaritySearchTopK = 10;
+inline constexpr int kDefaultKgHop1TopK = 50;
+inline constexpr int kDefaultKgHop2TopK = 20;
 
 inline constexpr std::size_t kDefaultMidTermFlushDeciderIntervalUserTurns = 10U;
 inline constexpr double kDefaultRetrievedMemoryRerankerMinScore = 0.5;
@@ -78,6 +80,8 @@ struct MemoryOrchestratorInit {
     std::shared_ptr<const isla::server::EmbeddingClient> retrieval_embedding_client = nullptr;
     std::string retrieval_embedding_model;
     int episode_similarity_search_top_k = kDefaultEpisodeSimilaritySearchTopK;
+    int kg_hop_1_top_k_per_entity = kDefaultKgHop1TopK;
+    int kg_hop_2_top_k_per_entity = kDefaultKgHop2TopK;
 };
 
 struct SleepCycleResult {
@@ -104,7 +108,9 @@ class MemoryOrchestrator {
         double retrieved_memory_reranker_min_score = kDefaultRetrievedMemoryRerankerMinScore,
         std::shared_ptr<const isla::server::EmbeddingClient> retrieval_embedding_client = nullptr,
         std::string retrieval_embedding_model = {},
-        int episode_similarity_search_top_k = kDefaultEpisodeSimilaritySearchTopK);
+        int episode_similarity_search_top_k = kDefaultEpisodeSimilaritySearchTopK,
+        int kg_hop_1_top_k_per_entity = kDefaultKgHop1TopK,
+        int kg_hop_2_top_k_per_entity = kDefaultKgHop2TopK);
 
     // Builds a fresh orchestrator with empty working-memory conversation state for the session.
     // Persistence and async mid-term components are optional and can be attached up front.
@@ -309,6 +315,8 @@ class MemoryOrchestrator {
     std::size_t next_episode_sequence_ = 1;
     double retrieved_memory_reranker_min_score_ = kDefaultRetrievedMemoryRerankerMinScore;
     int episode_similarity_search_top_k_ = kDefaultEpisodeSimilaritySearchTopK;
+    int kg_hop_1_top_k_per_entity_ = kDefaultKgHop1TopK;
+    int kg_hop_2_top_k_per_entity_ = kDefaultKgHop2TopK;
     bool session_persisted_ = false;
 };
 

--- a/server/memory/src/BUILD
+++ b/server/memory/src/BUILD
@@ -139,6 +139,17 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "retrieval_ranking",
+    srcs = ["shared/retrieval_ranking.cpp"],
+    hdrs = ["shared/retrieval_ranking.hpp"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/memory/include/isla/server/memory:memory_headers",
+        "@abseil-cpp//absl/log:log",
+    ],
+)
+
 cc_test(
     name = "llm_json_utils_test",
     srcs = ["shared/test/llm_json_utils_test.cpp"],
@@ -235,6 +246,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":identifier_utils",
+        ":retrieval_ranking",
         ":working_memory",
         ":memory_store",
         ":sleep_cycle_extraction_builder",
@@ -342,6 +354,15 @@ cc_test(
         ":working_memory",
         "@googletest//:gtest_main",
         "@nlohmann_json_upstream//:nlohmann_json",
+    ],
+)
+
+cc_test(
+    name = "retrieval_ranking_test",
+    srcs = ["shared/test/retrieval_ranking_test.cpp"],
+    deps = [
+        ":retrieval_ranking",
+        "@googletest//:gtest_main",
     ],
 )
 

--- a/server/memory/src/orchestrator/memory_orchestrator.cpp
+++ b/server/memory/src/orchestrator/memory_orchestrator.cpp
@@ -25,7 +25,8 @@ MemoryOrchestrator::MemoryOrchestrator(
     RetrievedMemoryRerankerPtr retrieved_memory_reranker,
     double retrieved_memory_reranker_min_score,
     std::shared_ptr<const isla::server::EmbeddingClient> retrieval_embedding_client,
-    std::string retrieval_embedding_model, int episode_similarity_search_top_k)
+    std::string retrieval_embedding_model, int episode_similarity_search_top_k,
+    int kg_hop_1_top_k_per_entity, int kg_hop_2_top_k_per_entity)
     : session_id_(std::move(session_id)), memory_(std::move(memory)), store_(std::move(store)),
       mid_term_flush_decider_(std::move(mid_term_flush_decider)),
       mid_term_compactor_(std::move(mid_term_compactor)),
@@ -36,11 +37,15 @@ MemoryOrchestrator::MemoryOrchestrator(
       mid_term_flush_decider_interval_user_turns_(mid_term_flush_decider_interval_user_turns),
       user_turns_since_last_mid_term_decider_run_(0), next_episode_sequence_(1),
       retrieved_memory_reranker_min_score_(retrieved_memory_reranker_min_score),
-      episode_similarity_search_top_k_(episode_similarity_search_top_k), session_persisted_(false) {
+      episode_similarity_search_top_k_(episode_similarity_search_top_k),
+      kg_hop_1_top_k_per_entity_(kg_hop_1_top_k_per_entity),
+      kg_hop_2_top_k_per_entity_(kg_hop_2_top_k_per_entity), session_persisted_(false) {
     CHECK_GT(mid_term_flush_decider_interval_user_turns_, 0U)
         << "mid_term_flush_decider_interval_user_turns must be at least 1";
     CHECK_GT(episode_similarity_search_top_k_, 0)
         << "episode_similarity_search_top_k must be at least 1";
+    CHECK_GT(kg_hop_1_top_k_per_entity_, 0) << "kg_hop_1_top_k_per_entity must be at least 1";
+    CHECK_GT(kg_hop_2_top_k_per_entity_, 0) << "kg_hop_2_top_k_per_entity must be at least 1";
 }
 
 absl::StatusOr<MemoryOrchestrator> MemoryOrchestrator::Create(std::string session_id,
@@ -59,6 +64,12 @@ absl::StatusOr<MemoryOrchestrator> MemoryOrchestrator::Create(std::string sessio
         return invalid_argument(
             "memory orchestrator episode_similarity_search_top_k must be at least 1");
     }
+    if (init.kg_hop_1_top_k_per_entity <= 0) {
+        return invalid_argument("memory orchestrator kg_hop_1_top_k_per_entity must be at least 1");
+    }
+    if (init.kg_hop_2_top_k_per_entity <= 0) {
+        return invalid_argument("memory orchestrator kg_hop_2_top_k_per_entity must be at least 1");
+    }
 
     absl::StatusOr<WorkingMemory> memory = WorkingMemory::Create(WorkingMemoryInit{
         .system_prompt = "",
@@ -72,7 +83,8 @@ absl::StatusOr<MemoryOrchestrator> MemoryOrchestrator::Create(std::string sessio
         init.mid_term_compactor, init.sleep_cycle_semantic_extractor,
         init.mid_term_flush_decider_interval_user_turns, init.retrieved_memory_reranker,
         init.retrieved_memory_reranker_min_score, init.retrieval_embedding_client,
-        init.retrieval_embedding_model, init.episode_similarity_search_top_k);
+        init.retrieval_embedding_model, init.episode_similarity_search_top_k,
+        init.kg_hop_1_top_k_per_entity, init.kg_hop_2_top_k_per_entity);
 }
 
 absl::StatusOr<std::string> MemoryOrchestrator::RenderFullWorkingMemory() const {

--- a/server/memory/src/orchestrator/memory_orchestrator_session.cpp
+++ b/server/memory/src/orchestrator/memory_orchestrator_session.cpp
@@ -18,6 +18,7 @@
 #include "isla/server/embedding_client.hpp"
 #include "isla/server/memory/identifier_utils.hpp"
 #include "isla/server/memory/working_memory.hpp"
+#include "server/memory/src/shared/retrieval_ranking.hpp"
 
 namespace isla::server::memory {
 namespace {
@@ -407,20 +408,24 @@ MemoryOrchestrator::RetrieveRelevantMemories(const Message& user_message) {
     std::unordered_set<std::string> seen_episode_ids;
     std::vector<RetrievedEpisodeCandidate> episode_candidates;
     std::unordered_set<std::string> related_entity_ids;
+    std::optional<Embedding> query_embedding;
 
     // --- Path 1: Direct episode similarity search (embedding-based) ---
     if (retrieval_embedding_client_ != nullptr && !retrieval_embedding_model_.empty()) {
-        const absl::StatusOr<Embedding> query_embedding =
+        const absl::StatusOr<Embedding> embedded_query =
             retrieval_embedding_client_->Embed(isla::server::EmbeddingRequest{
                 .model = retrieval_embedding_model_,
                 .text = user_message.content,
+                .output_dimensionality = kEmbeddingDimensions,
+                .telemetry_context = nullptr,
             });
-        if (!query_embedding.ok()) {
+        if (!embedded_query.ok()) {
             LOG(WARNING) << "MemoryOrchestrator failed to embed user query for episode similarity "
                             "search"
                          << " session_id=" << SanitizeForLog(session_id_) << " detail='"
-                         << SanitizeForLog(query_embedding.status().message()) << "'";
-        } else if (!query_embedding->empty()) {
+                         << SanitizeForLog(embedded_query.status().message()) << "'";
+        } else if (!embedded_query->empty()) {
+            query_embedding = *embedded_query;
             const absl::StatusOr<std::vector<LongTermEpisode>> similar_episodes =
                 store_->SearchLongTermEpisodesByEmbedding(user_id, *query_embedding,
                                                           episode_similarity_search_top_k_);
@@ -480,33 +485,127 @@ MemoryOrchestrator::RetrieveRelevantMemories(const Message& user_message) {
         }
     }
 
-    for (const std::string& entity_id : seed_entity_ids) {
-        const absl::StatusOr<std::vector<Relationship>> relationships =
-            store_->ListRelationshipsForEntity(entity_id);
-        if (!relationships.ok()) {
-            if (!absl::IsUnimplemented(relationships.status())) {
-                LOG(WARNING) << "MemoryOrchestrator failed to retrieve relationships for entity"
-                             << " session_id=" << SanitizeForLog(session_id_)
-                             << " entity_id=" << SanitizeForLog(entity_id) << " detail='"
-                             << SanitizeForLog(relationships.status().message()) << "'";
+    const auto append_relationship_candidate = [&](const Relationship& relationship) {
+        related_entity_ids.insert(relationship.from_entity_id);
+        related_entity_ids.insert(relationship.to_entity_id);
+        relationship_candidates.push_back(RetrievedRelationshipCandidate{
+            .relationship_id = relationship.relationship_id,
+            .from_text = relationship.from_entity_id,
+            .predicate = relationship.predicate,
+            .to_text = relationship.to_entity_id,
+            .weight = relationship.weight,
+        });
+    };
+
+    if (query_embedding.has_value()) {
+        std::unordered_set<std::string> seed_entity_id_set(seed_entity_ids.begin(),
+                                                           seed_entity_ids.end());
+        std::unordered_set<std::string> seen_hop_1_entity_ids;
+        std::vector<std::string> hop_1_entity_ids;
+        const auto collect_rankable_relationships =
+            [&](const std::vector<Relationship>& relationships) {
+                std::vector<Relationship> eligible_relationships;
+                eligible_relationships.reserve(relationships.size());
+                for (const Relationship& rel : relationships) {
+                    if (rel.is_archived || rel.user_id != user_id ||
+                        seen_relationship_ids.contains(rel.relationship_id)) {
+                        continue;
+                    }
+                    eligible_relationships.push_back(rel);
+                }
+                return eligible_relationships;
+            };
+
+        for (const std::string& entity_id : seed_entity_ids) {
+            const absl::StatusOr<std::vector<Relationship>> relationships =
+                store_->ListRelationshipsForEntity(entity_id);
+            if (!relationships.ok()) {
+                if (!absl::IsUnimplemented(relationships.status())) {
+                    LOG(WARNING) << "MemoryOrchestrator failed to retrieve relationships for entity"
+                                 << " session_id=" << SanitizeForLog(session_id_)
+                                 << " entity_id=" << SanitizeForLog(entity_id) << " detail='"
+                                 << SanitizeForLog(relationships.status().message()) << "'";
+                }
+                continue;
             }
-        } else {
+
+            const std::vector<Relationship> eligible_relationships =
+                collect_rankable_relationships(*relationships);
+            for (const Relationship& rel : RankEdgesBySimilarity(
+                     *query_embedding, eligible_relationships, kg_hop_1_top_k_per_entity_)) {
+                if (!seen_relationship_ids.insert(rel.relationship_id).second) {
+                    continue;
+                }
+                append_relationship_candidate(rel);
+
+                const auto maybe_enqueue_hop_1_entity =
+                    [&](const std::string& candidate_entity_id) {
+                        if (seed_entity_id_set.contains(candidate_entity_id) ||
+                            !seen_hop_1_entity_ids.insert(candidate_entity_id).second) {
+                            return;
+                        }
+                        hop_1_entity_ids.push_back(candidate_entity_id);
+                    };
+                maybe_enqueue_hop_1_entity(rel.from_entity_id);
+                maybe_enqueue_hop_1_entity(rel.to_entity_id);
+            }
+        }
+
+        for (const std::string& entity_id : hop_1_entity_ids) {
+            const absl::StatusOr<std::vector<Relationship>> relationships =
+                store_->ListRelationshipsForEntity(entity_id);
+            if (!relationships.ok()) {
+                if (!absl::IsUnimplemented(relationships.status())) {
+                    LOG(WARNING) << "MemoryOrchestrator failed to retrieve relationships for hop-1 "
+                                    "entity"
+                                 << " session_id=" << SanitizeForLog(session_id_)
+                                 << " entity_id=" << SanitizeForLog(entity_id) << " detail='"
+                                 << SanitizeForLog(relationships.status().message()) << "'";
+                }
+                continue;
+            }
+
+            const std::vector<Relationship> eligible_relationships =
+                collect_rankable_relationships(*relationships);
+            for (const Relationship& rel : RankEdgesBySimilarity(
+                     *query_embedding, eligible_relationships, kg_hop_2_top_k_per_entity_)) {
+                if (!seen_relationship_ids.insert(rel.relationship_id).second) {
+                    continue;
+                }
+                append_relationship_candidate(rel);
+            }
+        }
+    } else {
+        for (const std::string& entity_id : seed_entity_ids) {
+            const absl::StatusOr<std::vector<Relationship>> relationships =
+                store_->ListRelationshipsForEntity(entity_id);
+            if (!relationships.ok()) {
+                if (!absl::IsUnimplemented(relationships.status())) {
+                    LOG(WARNING) << "MemoryOrchestrator failed to retrieve relationships for entity"
+                                 << " session_id=" << SanitizeForLog(session_id_)
+                                 << " entity_id=" << SanitizeForLog(entity_id) << " detail='"
+                                 << SanitizeForLog(relationships.status().message()) << "'";
+                }
+                continue;
+            }
+
             for (const Relationship& rel : *relationships) {
                 if (rel.is_archived || rel.user_id != user_id ||
                     !seen_relationship_ids.insert(rel.relationship_id).second) {
                     continue;
                 }
-                related_entity_ids.insert(rel.from_entity_id);
-                related_entity_ids.insert(rel.to_entity_id);
-                relationship_candidates.push_back(RetrievedRelationshipCandidate{
-                    .relationship_id = rel.relationship_id,
-                    .from_text = rel.from_entity_id,
-                    .predicate = rel.predicate,
-                    .to_text = rel.to_entity_id,
-                    .weight = rel.weight,
-                });
+                append_relationship_candidate(rel);
             }
         }
+
+        std::sort(relationship_candidates.begin(), relationship_candidates.end(),
+                  [](const RetrievedRelationshipCandidate& lhs,
+                     const RetrievedRelationshipCandidate& rhs) {
+                      if (lhs.weight != rhs.weight) {
+                          return lhs.weight > rhs.weight;
+                      }
+                      return lhs.relationship_id < rhs.relationship_id;
+                  });
     }
 
     const std::vector<std::string> related_entity_ids_vector(related_entity_ids.begin(),
@@ -529,15 +628,6 @@ MemoryOrchestrator::RetrieveRelevantMemories(const Message& user_message) {
                      << " session_id=" << SanitizeForLog(session_id_) << " detail='"
                      << SanitizeForLog(related_entities.status().message()) << "'";
     }
-
-    std::sort(
-        relationship_candidates.begin(), relationship_candidates.end(),
-        [](const RetrievedRelationshipCandidate& lhs, const RetrievedRelationshipCandidate& rhs) {
-            if (lhs.weight != rhs.weight) {
-                return lhs.weight > rhs.weight;
-            }
-            return lhs.relationship_id < rhs.relationship_id;
-        });
     // Note: episode_candidates are intentionally NOT re-sorted here. They arrive from
     // similarity search in ascending cosine distance order (most relevant first), and we
     // want to preserve that ranking in the fallback path when the reranker is unavailable.

--- a/server/memory/src/orchestrator/test/memory_orchestrator_test.cpp
+++ b/server/memory/src/orchestrator/test/memory_orchestrator_test.cpp
@@ -2054,8 +2054,7 @@ TEST_F(MemoryOrchestratorTest,
 
     ASSERT_TRUE(handler->BeginSession(Ts("2026-03-08T13:59:59Z")).ok());
     const absl::StatusOr<UserQueryMemoryResult> result = handler->HandleUserQuery(
-        GatewayUserQuery("srv_test", "turn_001", "Tell me about Airi",
-                         Ts("2026-03-08T14:00:00Z")));
+        GatewayUserQuery("srv_test", "turn_001", "Tell me about Airi", Ts("2026-03-08T14:00:00Z")));
     ASSERT_TRUE(result.ok()) << result.status();
 
     const WorkingMemoryState& state = handler->memory().snapshot();
@@ -2472,9 +2471,8 @@ TEST_F(MemoryOrchestratorTest, HandleUserQueryHop1TopKIsAppliedPerSeedEntity) {
     ASSERT_TRUE(handler.ok()) << handler.status();
 
     ASSERT_TRUE(handler->BeginSession(Ts("2026-03-08T13:59:59Z")).ok());
-    const absl::StatusOr<UserQueryMemoryResult> result = handler->HandleUserQuery(
-        GatewayUserQuery("srv_test", "turn_001", "Tell me about Airi and Mochi",
-                         Ts("2026-03-08T14:00:00Z")));
+    const absl::StatusOr<UserQueryMemoryResult> result = handler->HandleUserQuery(GatewayUserQuery(
+        "srv_test", "turn_001", "Tell me about Airi and Mochi", Ts("2026-03-08T14:00:00Z")));
     ASSERT_TRUE(result.ok()) << result.status();
 
     const WorkingMemoryState& state = handler->memory().snapshot();

--- a/server/memory/src/orchestrator/test/memory_orchestrator_test.cpp
+++ b/server/memory/src/orchestrator/test/memory_orchestrator_test.cpp
@@ -1818,6 +1818,774 @@ TEST_F(MemoryOrchestratorTest, HandleUserQueryReturnsBothKgFactsAndSimilaritySea
     EXPECT_NE(state.retrieved_memory->find("User discussed their cat Mochi"), std::string::npos);
 }
 
+TEST_F(MemoryOrchestratorTest, HandleUserQueryPerformsTwoHopKgRetrieval) {
+    auto store = std::make_shared<RecordingMemoryStore>();
+    store->entities = {
+        Entity{
+            .entity_id = "entity_user",
+            .user_id = "user_001",
+            .label = "Airi",
+            .category = "person",
+            .active_model_text = std::string("Airi, the user."),
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_renderer",
+            .user_id = "user_001",
+            .label = "Renderer",
+            .category = "project",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_winding_order",
+            .user_id = "user_001",
+            .label = "Winding order",
+            .category = "concept",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+    store->relationships_by_entity["entity_user"] = {
+        Relationship{
+            .relationship_id = "rel_user_renderer",
+            .user_id = "user_001",
+            .from_entity_id = "entity_user",
+            .predicate = "uses",
+            .to_entity_id = "entity_renderer",
+            .embedding = Embedding{ 1.0, 0.0 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+    store->relationships_by_entity["entity_renderer"] = {
+        Relationship{
+            .relationship_id = "rel_renderer_winding",
+            .user_id = "user_001",
+            .from_entity_id = "entity_renderer",
+            .predicate = "requires",
+            .to_entity_id = "entity_winding_order",
+            .embedding = Embedding{ 0.9, 0.1 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+
+    auto compactor = std::make_shared<RecordingMidTermCompactor>();
+    auto embedding_client = std::make_shared<isla::server::test::MockEmbeddingClient>();
+    EXPECT_CALL(*embedding_client, Embed(_))
+        .WillOnce([&](const isla::server::EmbeddingRequest& request) -> absl::StatusOr<Embedding> {
+            if (!request.output_dimensionality.has_value()) {
+                return absl::InvalidArgumentError("query embedding request must set dimensions");
+            }
+            EXPECT_EQ(*request.output_dimensionality, kEmbeddingDimensions);
+            return Embedding{ 1.0, 0.0 };
+        });
+
+    absl::StatusOr<MemoryOrchestrator> handler = MakeHandlerWithCompactor(
+        compactor, store, nullptr, nullptr, kImmediateMidTermFlushDeciderIntervalUserTurns, nullptr,
+        kDefaultRetrievedMemoryRerankerMinScore, embedding_client, "test-embedding-model");
+    ASSERT_TRUE(handler.ok()) << handler.status();
+
+    ASSERT_TRUE(handler->BeginSession(Ts("2026-03-08T13:59:59Z")).ok());
+    const absl::StatusOr<UserQueryMemoryResult> result = handler->HandleUserQuery(GatewayUserQuery(
+        "srv_test", "turn_001", "What do I know about Airi?", Ts("2026-03-08T14:00:00Z")));
+    ASSERT_TRUE(result.ok()) << result.status();
+
+    const WorkingMemoryState& state = handler->memory().snapshot();
+    ASSERT_TRUE(state.retrieved_memory.has_value());
+    EXPECT_NE(state.retrieved_memory->find("Airi uses Renderer"), std::string::npos);
+    EXPECT_NE(state.retrieved_memory->find("Renderer requires Winding order"), std::string::npos);
+}
+
+TEST_F(MemoryOrchestratorTest, HandleUserQueryHop2DedupesWithHop1) {
+    auto store = std::make_shared<RecordingMemoryStore>();
+    store->entities = {
+        Entity{
+            .entity_id = "entity_user",
+            .user_id = "user_001",
+            .label = "Airi",
+            .category = "person",
+            .active_model_text = std::string("Airi, the user."),
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_renderer",
+            .user_id = "user_001",
+            .label = "Renderer",
+            .category = "project",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_bug",
+            .user_id = "user_001",
+            .label = "Winding order",
+            .category = "concept",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+    const Relationship duplicated_relationship{
+        .relationship_id = "rel_shared",
+        .user_id = "user_001",
+        .from_entity_id = "entity_user",
+        .predicate = "debugged",
+        .to_entity_id = "entity_bug",
+        .embedding = Embedding{ 0.95, 0.05 },
+        .created_at = Ts("2026-03-08T14:00:00Z"),
+    };
+    store->relationships_by_entity["entity_user"] = {
+        Relationship{
+            .relationship_id = "rel_user_renderer",
+            .user_id = "user_001",
+            .from_entity_id = "entity_user",
+            .predicate = "uses",
+            .to_entity_id = "entity_renderer",
+            .embedding = Embedding{ 1.0, 0.0 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        duplicated_relationship,
+    };
+    store->relationships_by_entity["entity_renderer"] = { duplicated_relationship };
+
+    auto compactor = std::make_shared<RecordingMidTermCompactor>();
+    auto embedding_client = std::make_shared<isla::server::test::MockEmbeddingClient>();
+    EXPECT_CALL(*embedding_client, Embed(_)).WillOnce(Return(Embedding{ 1.0, 0.0 }));
+
+    absl::StatusOr<MemoryOrchestrator> handler = MakeHandlerWithCompactor(
+        compactor, store, nullptr, nullptr, kImmediateMidTermFlushDeciderIntervalUserTurns, nullptr,
+        kDefaultRetrievedMemoryRerankerMinScore, embedding_client, "test-embedding-model");
+    ASSERT_TRUE(handler.ok()) << handler.status();
+
+    ASSERT_TRUE(handler->BeginSession(Ts("2026-03-08T13:59:59Z")).ok());
+    const absl::StatusOr<UserQueryMemoryResult> result = handler->HandleUserQuery(
+        GatewayUserQuery("srv_test", "turn_001", "Tell me about Airi", Ts("2026-03-08T14:00:00Z")));
+    ASSERT_TRUE(result.ok()) << result.status();
+
+    const WorkingMemoryState& state = handler->memory().snapshot();
+    ASSERT_TRUE(state.retrieved_memory.has_value());
+    const std::size_t fact_position = state.retrieved_memory->find("Airi debugged Winding order");
+    ASSERT_NE(fact_position, std::string::npos);
+    EXPECT_EQ(fact_position, state.retrieved_memory->rfind("Airi debugged Winding order"));
+}
+
+TEST_F(MemoryOrchestratorTest,
+       HandleUserQueryHop2BackfillsAfterFilteringDuplicateEdgesBeforeRanking) {
+    auto store = std::make_shared<RecordingMemoryStore>();
+    store->entities = {
+        Entity{
+            .entity_id = "entity_user",
+            .user_id = "user_001",
+            .label = "Airi",
+            .category = "person",
+            .active_model_text = std::string("Airi, the user."),
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_renderer",
+            .user_id = "user_001",
+            .label = "Renderer",
+            .category = "project",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_bug",
+            .user_id = "user_001",
+            .label = "Winding order",
+            .category = "concept",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_normals",
+            .user_id = "user_001",
+            .label = "Normals",
+            .category = "concept",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+    const Relationship duplicated_relationship{
+        .relationship_id = "rel_shared",
+        .user_id = "user_001",
+        .from_entity_id = "entity_user",
+        .predicate = "debugged",
+        .to_entity_id = "entity_bug",
+        .embedding = Embedding{ 0.99, 0.01 },
+        .created_at = Ts("2026-03-08T14:00:00Z"),
+    };
+    store->relationships_by_entity["entity_user"] = {
+        Relationship{
+            .relationship_id = "rel_user_renderer",
+            .user_id = "user_001",
+            .from_entity_id = "entity_user",
+            .predicate = "uses",
+            .to_entity_id = "entity_renderer",
+            .embedding = Embedding{ 1.0, 0.0 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        duplicated_relationship,
+    };
+    store->relationships_by_entity["entity_renderer"] = {
+        duplicated_relationship,
+        Relationship{
+            .relationship_id = "rel_renderer_normals",
+            .user_id = "user_001",
+            .from_entity_id = "entity_renderer",
+            .predicate = "touches",
+            .to_entity_id = "entity_normals",
+            .embedding = Embedding{ 0.9, 0.1 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+
+    auto compactor = std::make_shared<RecordingMidTermCompactor>();
+    auto embedding_client = std::make_shared<isla::server::test::MockEmbeddingClient>();
+    EXPECT_CALL(*embedding_client, Embed(_)).WillOnce(Return(Embedding{ 1.0, 0.0 }));
+
+    absl::StatusOr<MemoryOrchestrator> handler = MakeHandlerWithCompactor(
+        compactor, store, nullptr, nullptr, kImmediateMidTermFlushDeciderIntervalUserTurns, nullptr,
+        kDefaultRetrievedMemoryRerankerMinScore, embedding_client, "test-embedding-model",
+        kDefaultEpisodeSimilaritySearchTopK, kDefaultKgHop1TopK, 1);
+    ASSERT_TRUE(handler.ok()) << handler.status();
+
+    ASSERT_TRUE(handler->BeginSession(Ts("2026-03-08T13:59:59Z")).ok());
+    const absl::StatusOr<UserQueryMemoryResult> result = handler->HandleUserQuery(
+        GatewayUserQuery("srv_test", "turn_001", "Tell me about Airi",
+                         Ts("2026-03-08T14:00:00Z")));
+    ASSERT_TRUE(result.ok()) << result.status();
+
+    const WorkingMemoryState& state = handler->memory().snapshot();
+    ASSERT_TRUE(state.retrieved_memory.has_value());
+    EXPECT_NE(state.retrieved_memory->find("Airi debugged Winding order"), std::string::npos);
+    EXPECT_NE(state.retrieved_memory->find("Renderer touches Normals"), std::string::npos);
+}
+
+TEST_F(MemoryOrchestratorTest, HandleUserQueryHop2SkipsSeedEntities) {
+    auto store = std::make_shared<RecordingMemoryStore>();
+    store->entities = {
+        Entity{
+            .entity_id = "entity_user",
+            .user_id = "user_001",
+            .label = "Airi",
+            .category = "person",
+            .active_model_text = std::string("Airi, the user."),
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_mochi",
+            .user_id = "user_001",
+            .label = "Mochi",
+            .category = "pet",
+            .familiar_label_text = std::string("Mochi - Airi's cat"),
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_renderer",
+            .user_id = "user_001",
+            .label = "Renderer",
+            .category = "project",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+    store->relationships_by_entity["entity_user"] = {
+        Relationship{
+            .relationship_id = "rel_user_renderer",
+            .user_id = "user_001",
+            .from_entity_id = "entity_user",
+            .predicate = "uses",
+            .to_entity_id = "entity_renderer",
+            .embedding = Embedding{ 1.0, 0.0 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+    store->relationships_by_entity["entity_mochi"] = {
+        Relationship{
+            .relationship_id = "rel_mochi_renderer",
+            .user_id = "user_001",
+            .from_entity_id = "entity_mochi",
+            .predicate = "appears_in",
+            .to_entity_id = "entity_renderer",
+            .embedding = Embedding{ 0.9, 0.1 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+    store->relationships_by_entity["entity_renderer"] = {
+        Relationship{
+            .relationship_id = "rel_renderer_user",
+            .user_id = "user_001",
+            .from_entity_id = "entity_renderer",
+            .predicate = "helps",
+            .to_entity_id = "entity_user",
+            .embedding = Embedding{ 0.8, 0.2 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+
+    auto compactor = std::make_shared<RecordingMidTermCompactor>();
+    auto embedding_client = std::make_shared<isla::server::test::MockEmbeddingClient>();
+    EXPECT_CALL(*embedding_client, Embed(_)).WillOnce(Return(Embedding{ 1.0, 0.0 }));
+
+    absl::StatusOr<MemoryOrchestrator> handler = MakeHandlerWithCompactor(
+        compactor, store, nullptr, nullptr, kImmediateMidTermFlushDeciderIntervalUserTurns, nullptr,
+        kDefaultRetrievedMemoryRerankerMinScore, embedding_client, "test-embedding-model");
+    ASSERT_TRUE(handler.ok()) << handler.status();
+
+    ASSERT_TRUE(handler->BeginSession(Ts("2026-03-08T13:59:59Z")).ok());
+    const absl::StatusOr<UserQueryMemoryResult> result = handler->HandleUserQuery(GatewayUserQuery(
+        "srv_test", "turn_001", "Tell me about Airi and Mochi", Ts("2026-03-08T14:00:00Z")));
+    ASSERT_TRUE(result.ok()) << result.status();
+
+    EXPECT_EQ(std::count(store->list_relationships_requests.begin(),
+                         store->list_relationships_requests.end(), "entity_user"),
+              1);
+    EXPECT_EQ(std::count(store->list_relationships_requests.begin(),
+                         store->list_relationships_requests.end(), "entity_mochi"),
+              1);
+    EXPECT_EQ(std::count(store->list_relationships_requests.begin(),
+                         store->list_relationships_requests.end(), "entity_renderer"),
+              1);
+}
+
+TEST_F(MemoryOrchestratorTest, HandleUserQueryHop1RespectsTopKLimit) {
+    auto store = std::make_shared<RecordingMemoryStore>();
+    store->entities = {
+        Entity{
+            .entity_id = "entity_user",
+            .user_id = "user_001",
+            .label = "Airi",
+            .category = "person",
+            .active_model_text = std::string("Airi, the user."),
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_renderer",
+            .user_id = "user_001",
+            .label = "Renderer",
+            .category = "project",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_gameplay",
+            .user_id = "user_001",
+            .label = "Gameplay",
+            .category = "project",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+    store->relationships_by_entity["entity_user"] = {
+        Relationship{
+            .relationship_id = "rel_best",
+            .user_id = "user_001",
+            .from_entity_id = "entity_user",
+            .predicate = "uses",
+            .to_entity_id = "entity_renderer",
+            .embedding = Embedding{ 1.0, 0.0 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Relationship{
+            .relationship_id = "rel_filtered",
+            .user_id = "user_001",
+            .from_entity_id = "entity_user",
+            .predicate = "explores",
+            .to_entity_id = "entity_gameplay",
+            .embedding = Embedding{ 0.0, 1.0 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+
+    auto compactor = std::make_shared<RecordingMidTermCompactor>();
+    auto embedding_client = std::make_shared<isla::server::test::MockEmbeddingClient>();
+    EXPECT_CALL(*embedding_client, Embed(_)).WillOnce(Return(Embedding{ 1.0, 0.0 }));
+
+    absl::StatusOr<MemoryOrchestrator> handler = MakeHandlerWithCompactor(
+        compactor, store, nullptr, nullptr, kImmediateMidTermFlushDeciderIntervalUserTurns, nullptr,
+        kDefaultRetrievedMemoryRerankerMinScore, embedding_client, "test-embedding-model",
+        kDefaultEpisodeSimilaritySearchTopK, 1, kDefaultKgHop2TopK);
+    ASSERT_TRUE(handler.ok()) << handler.status();
+
+    ASSERT_TRUE(handler->BeginSession(Ts("2026-03-08T13:59:59Z")).ok());
+    const absl::StatusOr<UserQueryMemoryResult> result = handler->HandleUserQuery(
+        GatewayUserQuery("srv_test", "turn_001", "Tell me about Airi", Ts("2026-03-08T14:00:00Z")));
+    ASSERT_TRUE(result.ok()) << result.status();
+
+    const WorkingMemoryState& state = handler->memory().snapshot();
+    ASSERT_TRUE(state.retrieved_memory.has_value());
+    EXPECT_NE(state.retrieved_memory->find("Airi uses Renderer"), std::string::npos);
+    EXPECT_EQ(state.retrieved_memory->find("Airi explores Gameplay"), std::string::npos);
+}
+
+TEST_F(MemoryOrchestratorTest, HandleUserQueryHop2RespectsTopKLimit) {
+    auto store = std::make_shared<RecordingMemoryStore>();
+    store->entities = {
+        Entity{
+            .entity_id = "entity_user",
+            .user_id = "user_001",
+            .label = "Airi",
+            .category = "person",
+            .active_model_text = std::string("Airi, the user."),
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_renderer",
+            .user_id = "user_001",
+            .label = "Renderer",
+            .category = "project",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_winding_order",
+            .user_id = "user_001",
+            .label = "Winding order",
+            .category = "concept",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_normals",
+            .user_id = "user_001",
+            .label = "Normals",
+            .category = "concept",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+    store->relationships_by_entity["entity_user"] = {
+        Relationship{
+            .relationship_id = "rel_user_renderer",
+            .user_id = "user_001",
+            .from_entity_id = "entity_user",
+            .predicate = "uses",
+            .to_entity_id = "entity_renderer",
+            .embedding = Embedding{ 1.0, 0.0 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+    store->relationships_by_entity["entity_renderer"] = {
+        Relationship{
+            .relationship_id = "rel_best_hop2",
+            .user_id = "user_001",
+            .from_entity_id = "entity_renderer",
+            .predicate = "requires",
+            .to_entity_id = "entity_winding_order",
+            .embedding = Embedding{ 0.95, 0.05 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Relationship{
+            .relationship_id = "rel_filtered_hop2",
+            .user_id = "user_001",
+            .from_entity_id = "entity_renderer",
+            .predicate = "touches",
+            .to_entity_id = "entity_normals",
+            .embedding = Embedding{ 0.0, 1.0 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+
+    auto compactor = std::make_shared<RecordingMidTermCompactor>();
+    auto embedding_client = std::make_shared<isla::server::test::MockEmbeddingClient>();
+    EXPECT_CALL(*embedding_client, Embed(_)).WillOnce(Return(Embedding{ 1.0, 0.0 }));
+
+    absl::StatusOr<MemoryOrchestrator> handler = MakeHandlerWithCompactor(
+        compactor, store, nullptr, nullptr, kImmediateMidTermFlushDeciderIntervalUserTurns, nullptr,
+        kDefaultRetrievedMemoryRerankerMinScore, embedding_client, "test-embedding-model",
+        kDefaultEpisodeSimilaritySearchTopK, kDefaultKgHop1TopK, 1);
+    ASSERT_TRUE(handler.ok()) << handler.status();
+
+    ASSERT_TRUE(handler->BeginSession(Ts("2026-03-08T13:59:59Z")).ok());
+    const absl::StatusOr<UserQueryMemoryResult> result = handler->HandleUserQuery(
+        GatewayUserQuery("srv_test", "turn_001", "Tell me about Airi", Ts("2026-03-08T14:00:00Z")));
+    ASSERT_TRUE(result.ok()) << result.status();
+
+    const WorkingMemoryState& state = handler->memory().snapshot();
+    ASSERT_TRUE(state.retrieved_memory.has_value());
+    EXPECT_NE(state.retrieved_memory->find("Renderer requires Winding order"), std::string::npos);
+    EXPECT_EQ(state.retrieved_memory->find("Renderer touches Normals"), std::string::npos);
+}
+
+TEST_F(MemoryOrchestratorTest, HandleUserQueryGracefullyHandlesRelationshipsWithoutEmbeddings) {
+    auto store = std::make_shared<RecordingMemoryStore>();
+    store->entities = {
+        Entity{
+            .entity_id = "entity_user",
+            .user_id = "user_001",
+            .label = "Airi",
+            .category = "person",
+            .active_model_text = std::string("Airi, the user."),
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_renderer",
+            .user_id = "user_001",
+            .label = "Renderer",
+            .category = "project",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+    store->relationships_by_entity["entity_user"] = {
+        Relationship{
+            .relationship_id = "rel_no_embedding",
+            .user_id = "user_001",
+            .from_entity_id = "entity_user",
+            .predicate = "uses",
+            .to_entity_id = "entity_renderer",
+            .embedding = std::nullopt,
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+
+    auto compactor = std::make_shared<RecordingMidTermCompactor>();
+    auto embedding_client = std::make_shared<isla::server::test::MockEmbeddingClient>();
+    EXPECT_CALL(*embedding_client, Embed(_)).WillOnce(Return(Embedding{ 1.0, 0.0 }));
+
+    absl::StatusOr<MemoryOrchestrator> handler = MakeHandlerWithCompactor(
+        compactor, store, nullptr, nullptr, kImmediateMidTermFlushDeciderIntervalUserTurns, nullptr,
+        kDefaultRetrievedMemoryRerankerMinScore, embedding_client, "test-embedding-model");
+    ASSERT_TRUE(handler.ok()) << handler.status();
+
+    ASSERT_TRUE(handler->BeginSession(Ts("2026-03-08T13:59:59Z")).ok());
+    const absl::StatusOr<UserQueryMemoryResult> result = handler->HandleUserQuery(
+        GatewayUserQuery("srv_test", "turn_001", "Tell me about Airi", Ts("2026-03-08T14:00:00Z")));
+    ASSERT_TRUE(result.ok()) << result.status();
+
+    const WorkingMemoryState& state = handler->memory().snapshot();
+    ASSERT_TRUE(state.retrieved_memory.has_value());
+    EXPECT_NE(state.retrieved_memory->find("Airi uses Renderer"), std::string::npos);
+}
+
+TEST_F(MemoryOrchestratorTest, HandleUserQueryHop1TopKIsAppliedPerSeedEntity) {
+    auto store = std::make_shared<RecordingMemoryStore>();
+    store->entities = {
+        Entity{
+            .entity_id = "entity_user",
+            .user_id = "user_001",
+            .label = "Airi",
+            .category = "person",
+            .active_model_text = std::string("Airi, the user."),
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_mochi",
+            .user_id = "user_001",
+            .label = "Mochi",
+            .category = "pet",
+            .familiar_label_text = std::string("Mochi - Airi's cat"),
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_renderer",
+            .user_id = "user_001",
+            .label = "Renderer",
+            .category = "project",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_gameplay",
+            .user_id = "user_001",
+            .label = "Gameplay",
+            .category = "project",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_treats",
+            .user_id = "user_001",
+            .label = "Treats",
+            .category = "item",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_naps",
+            .user_id = "user_001",
+            .label = "Naps",
+            .category = "concept",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+    store->relationships_by_entity["entity_user"] = {
+        Relationship{
+            .relationship_id = "rel_user_best",
+            .user_id = "user_001",
+            .from_entity_id = "entity_user",
+            .predicate = "uses",
+            .to_entity_id = "entity_renderer",
+            .embedding = Embedding{ 1.0, 0.0 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Relationship{
+            .relationship_id = "rel_user_filtered",
+            .user_id = "user_001",
+            .from_entity_id = "entity_user",
+            .predicate = "explores",
+            .to_entity_id = "entity_gameplay",
+            .embedding = Embedding{ 0.0, 1.0 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+    store->relationships_by_entity["entity_mochi"] = {
+        Relationship{
+            .relationship_id = "rel_mochi_best",
+            .user_id = "user_001",
+            .from_entity_id = "entity_mochi",
+            .predicate = "likes",
+            .to_entity_id = "entity_treats",
+            .embedding = Embedding{ 0.95, 0.05 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Relationship{
+            .relationship_id = "rel_mochi_filtered",
+            .user_id = "user_001",
+            .from_entity_id = "entity_mochi",
+            .predicate = "takes",
+            .to_entity_id = "entity_naps",
+            .embedding = Embedding{ 0.0, 1.0 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+
+    auto compactor = std::make_shared<RecordingMidTermCompactor>();
+    auto embedding_client = std::make_shared<isla::server::test::MockEmbeddingClient>();
+    EXPECT_CALL(*embedding_client, Embed(_)).WillOnce(Return(Embedding{ 1.0, 0.0 }));
+
+    absl::StatusOr<MemoryOrchestrator> handler = MakeHandlerWithCompactor(
+        compactor, store, nullptr, nullptr, kImmediateMidTermFlushDeciderIntervalUserTurns, nullptr,
+        kDefaultRetrievedMemoryRerankerMinScore, embedding_client, "test-embedding-model",
+        kDefaultEpisodeSimilaritySearchTopK, 1, kDefaultKgHop2TopK);
+    ASSERT_TRUE(handler.ok()) << handler.status();
+
+    ASSERT_TRUE(handler->BeginSession(Ts("2026-03-08T13:59:59Z")).ok());
+    const absl::StatusOr<UserQueryMemoryResult> result = handler->HandleUserQuery(
+        GatewayUserQuery("srv_test", "turn_001", "Tell me about Airi and Mochi",
+                         Ts("2026-03-08T14:00:00Z")));
+    ASSERT_TRUE(result.ok()) << result.status();
+
+    const WorkingMemoryState& state = handler->memory().snapshot();
+    ASSERT_TRUE(state.retrieved_memory.has_value());
+    EXPECT_NE(state.retrieved_memory->find("Airi uses Renderer"), std::string::npos);
+    EXPECT_NE(state.retrieved_memory->find("Mochi likes Treats"), std::string::npos);
+    EXPECT_EQ(state.retrieved_memory->find("Airi explores Gameplay"), std::string::npos);
+    EXPECT_EQ(state.retrieved_memory->find("Mochi takes Naps"), std::string::npos);
+}
+
+TEST_F(MemoryOrchestratorTest, HandleUserQueryFallsBackToSingleHopWhenQueryEmbeddingFails) {
+    auto store = std::make_shared<RecordingMemoryStore>();
+    store->entities = {
+        Entity{
+            .entity_id = "entity_user",
+            .user_id = "user_001",
+            .label = "Airi",
+            .category = "person",
+            .active_model_text = std::string("Airi, the user."),
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_renderer",
+            .user_id = "user_001",
+            .label = "Renderer",
+            .category = "project",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_bug",
+            .user_id = "user_001",
+            .label = "Winding order",
+            .category = "concept",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Entity{
+            .entity_id = "entity_other",
+            .user_id = "user_001",
+            .label = "Gameplay",
+            .category = "project",
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+            .updated_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+    store->relationships_by_entity["entity_user"] = {
+        Relationship{
+            .relationship_id = "rel_high_weight",
+            .user_id = "user_001",
+            .from_entity_id = "entity_user",
+            .predicate = "uses",
+            .to_entity_id = "entity_renderer",
+            .weight = 10.0,
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+        Relationship{
+            .relationship_id = "rel_low_weight",
+            .user_id = "user_001",
+            .from_entity_id = "entity_user",
+            .predicate = "explores",
+            .to_entity_id = "entity_other",
+            .weight = 5.0,
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+    store->relationships_by_entity["entity_renderer"] = {
+        Relationship{
+            .relationship_id = "rel_hop2_only",
+            .user_id = "user_001",
+            .from_entity_id = "entity_renderer",
+            .predicate = "requires",
+            .to_entity_id = "entity_bug",
+            .weight = 50.0,
+            .embedding = Embedding{ 1.0, 0.0 },
+            .created_at = Ts("2026-03-08T14:00:00Z"),
+        },
+    };
+
+    auto compactor = std::make_shared<RecordingMidTermCompactor>();
+    auto embedding_client = std::make_shared<isla::server::test::MockEmbeddingClient>();
+    EXPECT_CALL(*embedding_client, Embed(_))
+        .WillOnce(Return(absl::InternalError("embedding service unavailable")));
+
+    absl::StatusOr<MemoryOrchestrator> handler = MakeHandlerWithCompactor(
+        compactor, store, nullptr, nullptr, kImmediateMidTermFlushDeciderIntervalUserTurns, nullptr,
+        kDefaultRetrievedMemoryRerankerMinScore, embedding_client, "test-embedding-model");
+    ASSERT_TRUE(handler.ok()) << handler.status();
+
+    ASSERT_TRUE(handler->BeginSession(Ts("2026-03-08T13:59:59Z")).ok());
+    const absl::StatusOr<UserQueryMemoryResult> result = handler->HandleUserQuery(
+        GatewayUserQuery("srv_test", "turn_001", "Tell me about Airi", Ts("2026-03-08T14:00:00Z")));
+    ASSERT_TRUE(result.ok()) << result.status();
+
+    const WorkingMemoryState& state = handler->memory().snapshot();
+    ASSERT_TRUE(state.retrieved_memory.has_value());
+    const std::size_t uses_position =
+        state.retrieved_memory->find("Airi uses Renderer (weight: 10)");
+    const std::size_t explores_position =
+        state.retrieved_memory->find("Airi explores Gameplay (weight: 5)");
+    ASSERT_NE(uses_position, std::string::npos);
+    ASSERT_NE(explores_position, std::string::npos);
+    EXPECT_LT(uses_position, explores_position);
+    EXPECT_EQ(state.retrieved_memory->find("Renderer requires Winding order (weight: 50)"),
+              std::string::npos);
+    EXPECT_EQ(std::count(store->list_relationships_requests.begin(),
+                         store->list_relationships_requests.end(), "entity_renderer"),
+              0);
+}
+
 TEST_F(MemoryOrchestratorTest, HandleUserQueryGracefullySkipsSimilaritySearchWhenEmbeddingFails) {
     auto store = std::make_shared<RecordingMemoryStore>();
     store->entities = {

--- a/server/memory/src/orchestrator/test/memory_orchestrator_test_support.hpp
+++ b/server/memory/src/orchestrator/test/memory_orchestrator_test_support.hpp
@@ -1,14 +1,10 @@
 ﻿#pragma once
 
-#include "isla/server/memory/conversation.hpp"
 #include "isla/server/memory/memory_orchestrator.hpp"
 #include "isla/server/memory/mid_term_compactor.hpp"
 #include "isla/server/memory/mid_term_flush_decider.hpp"
-#include "isla/server/memory/prompt_loader.hpp"
 #include "isla/server/memory/retrieved_memory_reranker.hpp"
 
-#include <algorithm>
-#include <atomic>
 #include <chrono>
 #include <functional>
 #include <future>
@@ -24,7 +20,6 @@
 #include "server/memory/src/mid_term/test/mid_term_compactor_mock.hpp"
 #include "server/memory/src/mid_term/test/mid_term_flush_decider_mock.hpp"
 #include "server/memory/src/shared/test/memory_store_mock.hpp"
-#include "server/src/embedding_client_mock.hpp"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
@@ -530,8 +525,7 @@ class MemoryOrchestratorTest : public ::testing::Test {
             semantic_extractor, mid_term_flush_decider_interval_user_turns,
             retrieved_memory_reranker, retrieved_memory_reranker_min_score,
             std::move(retrieval_embedding_client), std::move(retrieval_embedding_model),
-            episode_similarity_search_top_k, kg_hop_1_top_k_per_entity,
-            kg_hop_2_top_k_per_entity);
+            episode_similarity_search_top_k, kg_hop_1_top_k_per_entity, kg_hop_2_top_k_per_entity);
     }
 
     static absl::StatusOr<std::size_t> WaitForDrain(MemoryOrchestrator& orchestrator,

--- a/server/memory/src/orchestrator/test/memory_orchestrator_test_support.hpp
+++ b/server/memory/src/orchestrator/test/memory_orchestrator_test_support.hpp
@@ -20,6 +20,7 @@
 #include "server/memory/src/mid_term/test/mid_term_compactor_mock.hpp"
 #include "server/memory/src/mid_term/test/mid_term_flush_decider_mock.hpp"
 #include "server/memory/src/shared/test/memory_store_mock.hpp"
+#include "server/src/embedding_client_mock.hpp"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>

--- a/server/memory/src/orchestrator/test/memory_orchestrator_test_support.hpp
+++ b/server/memory/src/orchestrator/test/memory_orchestrator_test_support.hpp
@@ -3,6 +3,7 @@
 #include "isla/server/memory/memory_orchestrator.hpp"
 #include "isla/server/memory/mid_term_compactor.hpp"
 #include "isla/server/memory/mid_term_flush_decider.hpp"
+#include "isla/server/memory/prompt_loader.hpp"
 #include "isla/server/memory/retrieved_memory_reranker.hpp"
 
 #include <chrono>

--- a/server/memory/src/orchestrator/test/memory_orchestrator_test_support.hpp
+++ b/server/memory/src/orchestrator/test/memory_orchestrator_test_support.hpp
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -207,7 +208,15 @@ class RecordingMemoryStore final : public NiceMock<test::MockMemoryStore> {
         ON_CALL(*this, ListRelationshipsForEntity(_))
             .WillByDefault(
                 [this](std::string_view entity_id) -> absl::StatusOr<std::vector<Relationship>> {
-                    static_cast<void>(entity_id);
+                    list_relationships_requests.push_back(std::string(entity_id));
+                    if (!list_relationships_status.ok()) {
+                        return list_relationships_status;
+                    }
+                    const auto relationships_it =
+                        relationships_by_entity.find(std::string(entity_id));
+                    if (relationships_it != relationships_by_entity.end()) {
+                        return relationships_it->second;
+                    }
                     return relationships;
                 });
         ON_CALL(*this, ListLongTermEpisodesForEntity(_))
@@ -269,6 +278,8 @@ class RecordingMemoryStore final : public NiceMock<test::MockMemoryStore> {
     std::vector<LongTermEpisodeEntityLink> long_term_episode_entity_links;
     std::vector<Entity> entities;
     std::vector<Relationship> relationships;
+    std::unordered_map<std::string, std::vector<Relationship>> relationships_by_entity;
+    std::vector<std::string> list_relationships_requests;
     std::vector<LongTermEpisode> long_term_episodes;
     absl::Status upsert_session_status = absl::OkStatus();
     absl::Status upsert_user_working_memory_status = absl::OkStatus();
@@ -283,6 +294,7 @@ class RecordingMemoryStore final : public NiceMock<test::MockMemoryStore> {
     absl::Status upsert_long_term_episode_status = absl::OkStatus();
     absl::Status link_long_term_episode_entities_status = absl::OkStatus();
     absl::Status list_entities_status = absl::OkStatus();
+    absl::Status list_relationships_status = absl::OkStatus();
     std::vector<LongTermEpisode> search_long_term_episodes_results;
     absl::Status search_long_term_episodes_status = absl::OkStatus();
 };
@@ -502,7 +514,10 @@ class MemoryOrchestratorTest : public ::testing::Test {
         const RetrievedMemoryRerankerPtr& retrieved_memory_reranker = nullptr,
         double retrieved_memory_reranker_min_score = kDefaultRetrievedMemoryRerankerMinScore,
         std::shared_ptr<const isla::server::EmbeddingClient> retrieval_embedding_client = nullptr,
-        std::string retrieval_embedding_model = {}) {
+        std::string retrieval_embedding_model = {},
+        int episode_similarity_search_top_k = kDefaultEpisodeSimilaritySearchTopK,
+        int kg_hop_1_top_k_per_entity = kDefaultKgHop1TopK,
+        int kg_hop_2_top_k_per_entity = kDefaultKgHop2TopK) {
         absl::StatusOr<WorkingMemory> memory = WorkingMemory::Create(WorkingMemoryInit{
             .system_prompt = "You are Isla.",
             .user_id = "user_001",
@@ -514,7 +529,9 @@ class MemoryOrchestratorTest : public ::testing::Test {
             "srv_test", std::move(*memory), std::move(store), decider, compactor,
             semantic_extractor, mid_term_flush_decider_interval_user_turns,
             retrieved_memory_reranker, retrieved_memory_reranker_min_score,
-            std::move(retrieval_embedding_client), std::move(retrieval_embedding_model));
+            std::move(retrieval_embedding_client), std::move(retrieval_embedding_model),
+            episode_similarity_search_top_k, kg_hop_1_top_k_per_entity,
+            kg_hop_2_top_k_per_entity);
     }
 
     static absl::StatusOr<std::size_t> WaitForDrain(MemoryOrchestrator& orchestrator,

--- a/server/memory/src/shared/retrieval_ranking.cpp
+++ b/server/memory/src/shared/retrieval_ranking.cpp
@@ -6,8 +6,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <optional>
+#include <string>
 #include <string_view>
-#include <utility>
 #include <vector>
 
 #include "absl/log/log.h"

--- a/server/memory/src/shared/retrieval_ranking.cpp
+++ b/server/memory/src/shared/retrieval_ranking.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <string_view>
@@ -139,8 +140,8 @@ struct RankedRelationship {
 
 std::vector<Relationship> RankEdgesBySimilarity(const Embedding& query_embedding,
                                                 const std::vector<Relationship>& relationships,
-                                                int top_k) {
-    if (relationships.empty() || top_k <= 0) {
+                                                std::size_t top_k) {
+    if (relationships.empty() || top_k == 0U) {
         return {};
     }
 
@@ -170,8 +171,7 @@ std::vector<Relationship> RankEdgesBySimilarity(const Embedding& query_embedding
                   return lhs.relationship.relationship_id < rhs.relationship.relationship_id;
               });
 
-    const std::size_t limit =
-        std::min<std::size_t>(ranked_relationships.size(), static_cast<std::size_t>(top_k));
+    const std::size_t limit = std::min(ranked_relationships.size(), top_k);
     std::vector<Relationship> result;
     result.reserve(limit);
     for (std::size_t i = 0; i < limit; ++i) {

--- a/server/memory/src/shared/retrieval_ranking.cpp
+++ b/server/memory/src/shared/retrieval_ranking.cpp
@@ -132,8 +132,8 @@ SimilarityResult ComputeCosineSimilarity(const Embedding& lhs, const Embedding& 
     };
 }
 
-struct RankedRelationship {
-    Relationship relationship;
+struct RankedRelationshipIndex {
+    std::size_t index = 0;
     double score = kMissingEmbeddingScore;
 };
 
@@ -146,9 +146,10 @@ std::vector<Relationship> RankEdgesBySimilarity(const Embedding& query_embedding
         return {};
     }
 
-    std::vector<RankedRelationship> ranked_relationships;
+    std::vector<RankedRelationshipIndex> ranked_relationships;
     ranked_relationships.reserve(relationships.size());
-    for (const Relationship& relationship : relationships) {
+    for (std::size_t i = 0; i < relationships.size(); ++i) {
+        const Relationship& relationship = relationships[i];
         SimilarityResult similarity = SimilarityResult{
             .score = kMissingEmbeddingScore,
             .status = SimilarityStatus::kMissingEmbedding,
@@ -158,25 +159,27 @@ std::vector<Relationship> RankEdgesBySimilarity(const Embedding& query_embedding
             MaybeLogMalformedEmbedding(relationship.relationship_id, similarity.status,
                                        query_embedding.size(), relationship.embedding->size());
         }
-        ranked_relationships.push_back(RankedRelationship{
-            .relationship = relationship,
+        ranked_relationships.push_back(RankedRelationshipIndex{
+            .index = i,
             .score = similarity.score,
         });
     }
 
-    std::sort(ranked_relationships.begin(), ranked_relationships.end(),
-              [](const RankedRelationship& lhs, const RankedRelationship& rhs) {
-                  if (lhs.score != rhs.score) {
-                      return lhs.score > rhs.score;
-                  }
-                  return lhs.relationship.relationship_id < rhs.relationship.relationship_id;
-              });
-
     const std::size_t limit = std::min(ranked_relationships.size(), top_k);
+    std::partial_sort(ranked_relationships.begin(), ranked_relationships.begin() + limit,
+                      ranked_relationships.end(),
+                      [&](const RankedRelationshipIndex& lhs, const RankedRelationshipIndex& rhs) {
+                          if (lhs.score != rhs.score) {
+                              return lhs.score > rhs.score;
+                          }
+                          return relationships[lhs.index].relationship_id <
+                                 relationships[rhs.index].relationship_id;
+                      });
+
     std::vector<Relationship> result;
     result.reserve(limit);
     for (std::size_t i = 0; i < limit; ++i) {
-        result.push_back(std::move(ranked_relationships[i].relationship));
+        result.push_back(relationships[ranked_relationships[i].index]);
     }
     return result;
 }

--- a/server/memory/src/shared/retrieval_ranking.cpp
+++ b/server/memory/src/shared/retrieval_ranking.cpp
@@ -150,7 +150,7 @@ std::vector<Relationship> RankEdgesBySimilarity(const Embedding& query_embedding
     ranked_relationships.reserve(relationships.size());
     for (std::size_t i = 0; i < relationships.size(); ++i) {
         const Relationship& relationship = relationships[i];
-        SimilarityResult similarity = SimilarityResult{
+        auto similarity = SimilarityResult{
             .score = kMissingEmbeddingScore,
             .status = SimilarityStatus::kMissingEmbedding,
         };

--- a/server/memory/src/shared/retrieval_ranking.cpp
+++ b/server/memory/src/shared/retrieval_ranking.cpp
@@ -1,0 +1,183 @@
+#include "server/memory/src/shared/retrieval_ranking.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "absl/log/log.h"
+
+namespace isla::server::memory {
+namespace {
+
+constexpr double kMissingEmbeddingScore = -std::numeric_limits<double>::infinity();
+constexpr std::uint64_t kMalformedEmbeddingLogFrequency = 100;
+
+enum class SimilarityStatus {
+    kOk,
+    kMissingEmbedding,
+    kEmptyEmbedding,
+    kDimensionMismatch,
+    kNonFiniteValue,
+    kZeroNorm,
+};
+
+struct SimilarityResult {
+    double score = kMissingEmbeddingScore;
+    SimilarityStatus status = SimilarityStatus::kMissingEmbedding;
+};
+
+std::string_view SimilarityStatusToString(SimilarityStatus status) {
+    switch (status) {
+    case SimilarityStatus::kOk:
+        return "ok";
+    case SimilarityStatus::kMissingEmbedding:
+        return "missing_embedding";
+    case SimilarityStatus::kEmptyEmbedding:
+        return "empty_embedding";
+    case SimilarityStatus::kDimensionMismatch:
+        return "dimension_mismatch";
+    case SimilarityStatus::kNonFiniteValue:
+        return "non_finite_value";
+    case SimilarityStatus::kZeroNorm:
+        return "zero_norm";
+    }
+    return "unknown";
+}
+
+void MaybeLogMalformedEmbedding(std::string_view relationship_id, SimilarityStatus status,
+                                std::size_t query_dimensions,
+                                std::optional<std::size_t> relationship_dimensions) {
+    if (status == SimilarityStatus::kOk || status == SimilarityStatus::kMissingEmbedding) {
+        return;
+    }
+
+    static std::atomic<std::uint64_t> malformed_embedding_log_count = 0;
+    const std::uint64_t count =
+        malformed_embedding_log_count.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (count > 1 && count % kMalformedEmbeddingLogFrequency != 0) {
+        return;
+    }
+
+    LOG(WARNING) << "RankEdgesBySimilarity treating malformed relationship embedding as low score"
+                 << " relationship_id=" << relationship_id
+                 << " reason=" << SimilarityStatusToString(status)
+                 << " query_dimensions=" << query_dimensions << " relationship_dimensions="
+                 << (relationship_dimensions.has_value() ? std::to_string(*relationship_dimensions)
+                                                         : std::string("null"))
+                 << " malformed_embedding_log_count=" << count;
+}
+
+SimilarityResult ComputeCosineSimilarity(const Embedding& lhs, const Embedding& rhs) {
+    if (lhs.empty() || rhs.empty()) {
+        return SimilarityResult{
+            .score = kMissingEmbeddingScore,
+            .status = SimilarityStatus::kEmptyEmbedding,
+        };
+    }
+    if (lhs.size() != rhs.size()) {
+        return SimilarityResult{
+            .score = kMissingEmbeddingScore,
+            .status = SimilarityStatus::kDimensionMismatch,
+        };
+    }
+
+    double dot_product = 0.0;
+    double lhs_norm_squared = 0.0;
+    double rhs_norm_squared = 0.0;
+    for (std::size_t i = 0; i < lhs.size(); ++i) {
+        dot_product += lhs[i] * rhs[i];
+        lhs_norm_squared += lhs[i] * lhs[i];
+        rhs_norm_squared += rhs[i] * rhs[i];
+    }
+
+    if (!std::isfinite(dot_product) || !std::isfinite(lhs_norm_squared) ||
+        !std::isfinite(rhs_norm_squared)) {
+        return SimilarityResult{
+            .score = kMissingEmbeddingScore,
+            .status = SimilarityStatus::kNonFiniteValue,
+        };
+    }
+    if (lhs_norm_squared <= 0.0 || rhs_norm_squared <= 0.0) {
+        return SimilarityResult{
+            .score = kMissingEmbeddingScore,
+            .status = SimilarityStatus::kZeroNorm,
+        };
+    }
+
+    const double denominator = std::sqrt(lhs_norm_squared) * std::sqrt(rhs_norm_squared);
+    if (!std::isfinite(denominator) || denominator <= 0.0) {
+        return SimilarityResult{
+            .score = kMissingEmbeddingScore,
+            .status = SimilarityStatus::kZeroNorm,
+        };
+    }
+
+    const double similarity = dot_product / denominator;
+    if (!std::isfinite(similarity)) {
+        return SimilarityResult{
+            .score = kMissingEmbeddingScore,
+            .status = SimilarityStatus::kNonFiniteValue,
+        };
+    }
+    return SimilarityResult{
+        .score = similarity,
+        .status = SimilarityStatus::kOk,
+    };
+}
+
+struct RankedRelationship {
+    Relationship relationship;
+    double score = kMissingEmbeddingScore;
+};
+
+} // namespace
+
+std::vector<Relationship> RankEdgesBySimilarity(const Embedding& query_embedding,
+                                                const std::vector<Relationship>& relationships,
+                                                int top_k) {
+    if (relationships.empty() || top_k <= 0) {
+        return {};
+    }
+
+    std::vector<RankedRelationship> ranked_relationships;
+    ranked_relationships.reserve(relationships.size());
+    for (const Relationship& relationship : relationships) {
+        SimilarityResult similarity = SimilarityResult{
+            .score = kMissingEmbeddingScore,
+            .status = SimilarityStatus::kMissingEmbedding,
+        };
+        if (relationship.embedding.has_value()) {
+            similarity = ComputeCosineSimilarity(query_embedding, *relationship.embedding);
+            MaybeLogMalformedEmbedding(relationship.relationship_id, similarity.status,
+                                       query_embedding.size(), relationship.embedding->size());
+        }
+        ranked_relationships.push_back(RankedRelationship{
+            .relationship = relationship,
+            .score = similarity.score,
+        });
+    }
+
+    std::sort(ranked_relationships.begin(), ranked_relationships.end(),
+              [](const RankedRelationship& lhs, const RankedRelationship& rhs) {
+                  if (lhs.score != rhs.score) {
+                      return lhs.score > rhs.score;
+                  }
+                  return lhs.relationship.relationship_id < rhs.relationship.relationship_id;
+              });
+
+    const std::size_t limit =
+        std::min<std::size_t>(ranked_relationships.size(), static_cast<std::size_t>(top_k));
+    std::vector<Relationship> result;
+    result.reserve(limit);
+    for (std::size_t i = 0; i < limit; ++i) {
+        result.push_back(std::move(ranked_relationships[i].relationship));
+    }
+    return result;
+}
+
+} // namespace isla::server::memory

--- a/server/memory/src/shared/retrieval_ranking.hpp
+++ b/server/memory/src/shared/retrieval_ranking.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <vector>
 
 #include "isla/server/memory/memory_types.hpp"
@@ -11,6 +12,6 @@ namespace isla::server::memory {
 // surfaced as a deterministic fallback.
 [[nodiscard]] std::vector<Relationship>
 RankEdgesBySimilarity(const Embedding& query_embedding,
-                      const std::vector<Relationship>& relationships, int top_k);
+                      const std::vector<Relationship>& relationships, std::size_t top_k);
 
 } // namespace isla::server::memory

--- a/server/memory/src/shared/retrieval_ranking.hpp
+++ b/server/memory/src/shared/retrieval_ranking.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <vector>
+
+#include "isla/server/memory/memory_types.hpp"
+
+namespace isla::server::memory {
+
+// Ranks relationship edges by cosine similarity to the query embedding. Relationships without a
+// usable embedding are treated as very low score but remain eligible so older rows can still be
+// surfaced as a deterministic fallback.
+[[nodiscard]] std::vector<Relationship>
+RankEdgesBySimilarity(const Embedding& query_embedding,
+                      const std::vector<Relationship>& relationships, int top_k);
+
+} // namespace isla::server::memory

--- a/server/memory/src/shared/test/retrieval_ranking_test.cpp
+++ b/server/memory/src/shared/test/retrieval_ranking_test.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <optional>
 #include <string>
 #include <utility>

--- a/server/memory/src/shared/test/retrieval_ranking_test.cpp
+++ b/server/memory/src/shared/test/retrieval_ranking_test.cpp
@@ -1,0 +1,120 @@
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "server/memory/src/shared/retrieval_ranking.hpp"
+
+#include <gtest/gtest.h>
+
+namespace isla::server::memory {
+namespace {
+
+Relationship MakeRelationship(std::string relationship_id, std::optional<Embedding> embedding) {
+    return Relationship{
+        .relationship_id = std::move(relationship_id),
+        .user_id = "user_001",
+        .from_entity_id = "from_entity",
+        .predicate = "related_to",
+        .to_entity_id = "to_entity",
+        .embedding = std::move(embedding),
+        .created_at = {},
+    };
+}
+
+TEST(RetrievalRankingTest, RankEdgesBySimilarityOrdersBySimilarity) {
+    const Embedding query_embedding{ 1.0, 0.0 };
+    const std::vector<Relationship> relationships = {
+        MakeRelationship("rel_low", Embedding{ 0.0, 1.0 }),
+        MakeRelationship("rel_high", Embedding{ 1.0, 0.0 }),
+        MakeRelationship("rel_mid", Embedding{ 0.6, 0.8 }),
+    };
+
+    const std::vector<Relationship> ranked =
+        RankEdgesBySimilarity(query_embedding, relationships, 3);
+
+    ASSERT_EQ(ranked.size(), 3U);
+    EXPECT_EQ(ranked[0].relationship_id, "rel_high");
+    EXPECT_EQ(ranked[1].relationship_id, "rel_mid");
+    EXPECT_EQ(ranked[2].relationship_id, "rel_low");
+}
+
+TEST(RetrievalRankingTest, RankEdgesBySimilarityBreaksTiesByRelationshipId) {
+    const Embedding query_embedding{ 1.0, 0.0 };
+    const std::vector<Relationship> relationships = {
+        MakeRelationship("rel_b", Embedding{ 1.0, 0.0 }),
+        MakeRelationship("rel_a", Embedding{ 1.0, 0.0 }),
+    };
+
+    const std::vector<Relationship> ranked =
+        RankEdgesBySimilarity(query_embedding, relationships, 2);
+
+    ASSERT_EQ(ranked.size(), 2U);
+    EXPECT_EQ(ranked[0].relationship_id, "rel_a");
+    EXPECT_EQ(ranked[1].relationship_id, "rel_b");
+}
+
+TEST(RetrievalRankingTest, RankEdgesBySimilarityKeepsNullEmbeddingsEligible) {
+    const Embedding query_embedding{ 1.0, 0.0 };
+    const std::vector<Relationship> relationships = {
+        MakeRelationship("rel_null", std::nullopt),
+        MakeRelationship("rel_ranked", Embedding{ 1.0, 0.0 }),
+    };
+
+    const std::vector<Relationship> ranked =
+        RankEdgesBySimilarity(query_embedding, relationships, 2);
+
+    ASSERT_EQ(ranked.size(), 2U);
+    EXPECT_EQ(ranked[0].relationship_id, "rel_ranked");
+    EXPECT_EQ(ranked[1].relationship_id, "rel_null");
+}
+
+TEST(RetrievalRankingTest, RankEdgesBySimilarityTruncatesToTopK) {
+    const Embedding query_embedding{ 1.0, 0.0 };
+    const std::vector<Relationship> relationships = {
+        MakeRelationship("rel_1", Embedding{ 1.0, 0.0 }),
+        MakeRelationship("rel_2", Embedding{ 0.8, 0.2 }),
+        MakeRelationship("rel_3", Embedding{ 0.0, 1.0 }),
+    };
+
+    const std::vector<Relationship> ranked =
+        RankEdgesBySimilarity(query_embedding, relationships, 2);
+
+    ASSERT_EQ(ranked.size(), 2U);
+    EXPECT_EQ(ranked[0].relationship_id, "rel_1");
+    EXPECT_EQ(ranked[1].relationship_id, "rel_2");
+}
+
+TEST(RetrievalRankingTest, RankEdgesBySimilarityTreatsDimensionMismatchAsLowScore) {
+    const Embedding query_embedding{ 1.0, 0.0 };
+    const std::vector<Relationship> relationships = {
+        MakeRelationship("rel_mismatch", Embedding{ 1.0, 0.0, 0.0 }),
+        MakeRelationship("rel_valid", Embedding{ 1.0, 0.0 }),
+    };
+
+    const std::vector<Relationship> ranked =
+        RankEdgesBySimilarity(query_embedding, relationships, 2);
+
+    ASSERT_EQ(ranked.size(), 2U);
+    EXPECT_EQ(ranked[0].relationship_id, "rel_valid");
+    EXPECT_EQ(ranked[1].relationship_id, "rel_mismatch");
+}
+
+TEST(RetrievalRankingTest, RankEdgesBySimilarityTreatsNonFiniteEmbeddingAsLowScore) {
+    const Embedding query_embedding{ 1.0, 0.0 };
+    const std::vector<Relationship> relationships = {
+        MakeRelationship("rel_non_finite",
+                         Embedding{ std::numeric_limits<double>::infinity(), 0.0 }),
+        MakeRelationship("rel_valid", Embedding{ 1.0, 0.0 }),
+    };
+
+    const std::vector<Relationship> ranked =
+        RankEdgesBySimilarity(query_embedding, relationships, 2);
+
+    ASSERT_EQ(ranked.size(), 2U);
+    EXPECT_EQ(ranked[0].relationship_id, "rel_valid");
+    EXPECT_EQ(ranked[1].relationship_id, "rel_non_finite");
+}
+
+} // namespace
+} // namespace isla::server::memory


### PR DESCRIPTION
Introduce a new function to rank relationships based on cosine similarity to a query embedding. Add enums for handling similarity results and statuses, implement logging for malformed embeddings, and create unit tests to ensure correct ranking behavior. Update the memory store to support new relationship handling and tracking.

#43